### PR TITLE
ASRC-230: improve AbstractNumericalVariable interface

### DIFF
--- a/install/resources/create_database.sql
+++ b/install/resources/create_database.sql
@@ -5,11 +5,11 @@ USE srcalc;
 
 create table boolean_variable (id integer not null, primary key (id));
 create table cpt (id integer not null auto_increment, active boolean not null, complexity varchar(255), cpt_code varchar(255), long_description varchar(255), rvu float not null, short_description varchar(255), primary key (id));
-create table discrete_numerical_var (max_inclusive boolean not null, max_value float not null, min_inclusive boolean not null, min_value float not null, units varchar(40) not null, id integer not null, primary key (id));
+create table discrete_numerical_var (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
 create table discrete_numerical_var_category (variable_id integer not null, option_value varchar(80) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, primary key (variable_id, option_value, lower_bound, lower_inclusive, upper_bound, upper_inclusive));
 create table multi_select_variable (display_type varchar(255), id integer not null, primary key (id));
 create table multi_select_variable_option (variable_id integer not null, option_value varchar(80) not null, option_index integer not null, primary key (variable_id, option_index));
-create table numerical_variable (max_inclusive boolean not null, max_value float not null, min_inclusive boolean not null, min_value float not null, units varchar(40) not null, id integer not null, primary key (id));
+create table numerical_variable (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
 create table procedure_variable (id integer not null, primary key (id));
 create table risk_model (id integer not null auto_increment, constant float, display_name varchar(80) not null, primary key (id));
 create table risk_model_boolean_term (risk_model_id integer not null, variable integer not null, coefficient float not null, primary key (risk_model_id, variable, coefficient));

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/DiscreteNumericalValue.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/DiscreteNumericalValue.java
@@ -40,7 +40,7 @@ public class DiscreteNumericalValue implements DiscreteValue
                     throws ValueTooLowException, ValueTooHighException
     {
         // Ensure the value is in within range.
-        variable.checkValue(numericalValue);
+        variable.getValidRange().checkValue(numericalValue);
 
         final Category category = variable.getContainingCategory(numericalValue);
         if (category == null)

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/NumericalValue.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/NumericalValue.java
@@ -18,7 +18,7 @@ public class NumericalValue implements Value
             throws ValueTooLowException, ValueTooHighException
     {
         fVariable = variable;
-        fValue = fVariable.checkValue(value);
+        fValue = fVariable.getValidRange().checkValue(value);
     }
     
     @Override

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/AbstractNumericalVariable.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/AbstractNumericalVariable.java
@@ -37,7 +37,7 @@ public abstract class AbstractNumericalVariable extends AbstractVariable
     
     /**
      * Returns the range of valid values for the variable. The default is
-     * [0.0,100.0].
+     * [0.0,200.0].
      */
     @Embedded
     public NumericalRange getValidRange()

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/AbstractNumericalVariable.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/AbstractNumericalVariable.java
@@ -1,5 +1,7 @@
 package gov.va.med.srcalc.domain.model;
 
+import java.util.Objects;
+
 import javax.persistence.*;
 
 @MappedSuperclass
@@ -10,7 +12,7 @@ public abstract class AbstractNumericalVariable extends AbstractVariable
      */
     public static final int UNITS_MAX = 40;
     
-    private NumericalRange fRange = new NumericalRange(0.0f, true, Float.POSITIVE_INFINITY, true);
+    private NumericalRange fRange = new NumericalRange(0.0f, true, 200.0f, true);
 
     private String fUnits = "";
 
@@ -32,52 +34,24 @@ public abstract class AbstractNumericalVariable extends AbstractVariable
     {
         super(displayName, group, key);
     }
-
+    
     /**
-     * The minimum allowed value for this variable. Default 0.
+     * Returns the range of valid values for the variable. The default is
+     * [0.0,100.0].
      */
-    public float getMinValue()
+    @Embedded
+    public NumericalRange getValidRange()
     {
-        return fRange.getLowerBound();
-    }
-
-    public void setMinValue(final float minValue)
-    {
-        this.fRange.setLowerBound(minValue);
-    }
-    
-    public boolean getMinInclusive()
-    {
-    	return fRange.isLowerInclusive();
-    }
-
-    public void setMinInclusive(final boolean inclusive)
-    {
-    	this.fRange.setLowerInclusive(inclusive);
-    }
-    
-    public boolean getMaxInclusive()
-    {
-    	return fRange.isUpperInclusive();
-    }
-
-    public void setMaxInclusive(final boolean inclusive)
-    {
-    	this.fRange.setUpperInclusive(inclusive);
+        return fRange;
     }
     
     /**
-     * The maximum allowed value for this variable. Default
-     * {@link Float#POSITIVE_INFINITY}.
+     * Sets the range of valid values for the variable.
+     * @throws NullPointerException if the given range is null
      */
-    public float getMaxValue()
+    public void setValidRange(final NumericalRange range)
     {
-        return fRange.getUpperBound();
-    }
-
-    public void setMaxValue(final float maxValue)
-    {
-        this.fRange.setUpperBound(maxValue);
+        fRange = Objects.requireNonNull(range);
     }
     
     /**
@@ -105,51 +79,5 @@ public abstract class AbstractNumericalVariable extends AbstractVariable
             throw new IllegalArgumentException("The units must be 40 characters or less.");
         }
         fUnits = units;
-    }
-
-    /**
-     * Checks the given value against the configured minimum and maximum bounds.
-     * If the value is valid, returns the value. Otherwise, throws an {@link
-     * InvalidValueException}.
-     * @return the valid value for convenience
-     * @throws ValueTooLowException if the value is below the minimum
-     * @throws ValueTooHighException if the value is above the minimum
-     */
-    public float checkValue(final float value)
-            throws ValueTooLowException, ValueTooHighException
-    {
-    	if(fRange.isLowerInclusive())
-    	{
-    		if(value < getMinValue())
-    		{
-    			throw new ValueTooLowException(ValueTooLowException.ERROR_CODE_INCLUSIVE,
-                    "value must be greater than or equal to " + getMinValue());
-    		}
-    	}
-    	else
-    	{
-    		if (value <= getMinValue())
-    		{
-    			throw new ValueTooLowException(ValueTooLowException.ERROR_CODE_EXCLUSIVE,
-                    "value must be greater than " + getMinValue());
-    		}
-    	}
-        if (fRange.isUpperInclusive())
-        {
-        	if(value > getMaxValue())
-        	{
-        		throw new ValueTooHighException(ValueTooHighException.ERROR_CODE_INCLUSIVE,
-                    "value must be less than or equal to " + getMaxValue());
-        	}
-        }
-        else
-        {
-        	if(value >= getMaxValue())
-        	{
-        		throw new ValueTooHighException(ValueTooHighException.ERROR_CODE_EXCLUSIVE,
-                    "value must be less than " + getMaxValue());
-        	}
-        }
-        return value;
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/NumericalRange.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/NumericalRange.java
@@ -193,6 +193,56 @@ public final class NumericalRange implements Comparable<NumericalRange>
     }
     
     /**
+     * Checks the given value against this range. If the value is in the range,
+     * returns the value. Otherwise, throws an {@link InvalidValueException}.
+     * @return the valid value for convenience
+     * @throws ValueTooLowException if the value is below the minimum
+     * @throws ValueTooHighException if the value is above the minimum
+     */
+    public float checkValue(final float value)
+            throws ValueTooLowException, ValueTooHighException
+    {
+        if (fLowerInclusive)
+        {
+            if (value < fLowerBound)
+            {
+                throw new ValueTooLowException(
+                        ValueTooLowException.ERROR_CODE_INCLUSIVE,
+                        "value must be greater than or equal to " + fLowerBound);
+            }
+        }
+        else
+        {
+            if (value <= fLowerBound)
+            {
+                throw new ValueTooLowException(
+                        ValueTooLowException.ERROR_CODE_EXCLUSIVE,
+                        "value must be greater than " + fLowerBound);
+            }
+        }
+
+        if (fUpperInclusive)
+        {
+            if (value > fUpperBound)
+            {
+                throw new ValueTooHighException(
+                        ValueTooHighException.ERROR_CODE_INCLUSIVE,
+                        "value must be less than or equal to " + fUpperBound);
+            }
+        }
+        else
+        {
+            if (value >= fUpperBound)
+            {
+                throw new ValueTooHighException(
+                        ValueTooHighException.ERROR_CODE_EXCLUSIVE,
+                        "value must be less than " + fUpperBound);
+            }
+        }
+        return value;
+    }
+    
+    /**
      * Returns the interval in mathematical notation. (See class Javadocs.)
      */
     @Override

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/InputParserVisitor.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/InputParserVisitor.java
@@ -158,7 +158,7 @@ public class InputParserVisitor extends ExceptionlessVariableVisitor
             rejectDynamicValue(
                     variable.getKey(),
                     ex.getErrorCode(),
-                    new Object[]{ variable.getMinValue() },
+                    new Object[]{ variable.getValidRange().getLowerBound() },
                     ex.getMessage());
         }
         catch (final ValueTooHighException ex)
@@ -166,7 +166,7 @@ public class InputParserVisitor extends ExceptionlessVariableVisitor
             rejectDynamicValue(
                     variable.getKey(),
                     ex.getErrorCode(),
-                    new Object[]{ variable.getMaxValue() },
+                    new Object[]{ variable.getValidRange().getUpperBound() },
                     ex.getMessage());
         }
     }
@@ -223,7 +223,7 @@ public class InputParserVisitor extends ExceptionlessVariableVisitor
                 rejectDynamicValue(
                         numericalName,
                         ex.getErrorCode(),
-                        new Object[]{ variable.getMinValue() },
+                        new Object[]{ variable.getValidRange().getLowerBound() },
                         ex.getMessage());
             }
             catch (final ValueTooHighException ex)
@@ -231,7 +231,7 @@ public class InputParserVisitor extends ExceptionlessVariableVisitor
                 rejectDynamicValue(
                         numericalName,
                         ex.getErrorCode(),
-                        new Object[]{ variable.getMaxValue() },
+                        new Object[]{ variable.getValidRange().getUpperBound() },
                         ex.getMessage());
             }
         }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/DiscreteNumericalValueTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/DiscreteNumericalValueTest.java
@@ -65,15 +65,6 @@ public class DiscreteNumericalValueTest
         DiscreteNumericalValue.fromNumerical(var, 1.0f);
     }
     
-    @Test(expected = ValueTooLowException.class)
-    public final void testNumericalLowBoundInclusiveFail() throws Exception
-    {
-    	// There is an accompanying test for Upper Bound in {@link NumericalValueTest}
-    	final DiscreteNumericalVariable var = SampleModels.wbcVariable();
-    	var.setMinInclusive(false);
-        DiscreteNumericalValue.fromNumerical(var, 2.0f);
-    }
-    
     @Test
     public final void testNumericalLowBoundInclusivePass() throws Exception
     {

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/NumericalValueTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/NumericalValueTest.java
@@ -37,15 +37,6 @@ public class NumericalValueTest
         new NumericalValue(var, -1);
     }
     
-    @Test(expected = ValueTooHighException.class)
-    public final void testNumericalUpperBoundInclusiveFail() throws Exception
-    {
-    	// There is an accompanying test for lower bound in {@link DiscreteNumericalValueTest}
-    	final DiscreteNumericalVariable var = SampleModels.wbcVariable();
-    	var.setMaxInclusive(false);
-        DiscreteNumericalValue.fromNumerical(var, 50.0f);
-    }
-    
     @Test
     public final void testNumericalUpperBoundInclusivePass() throws Exception
     {

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/NumericalRangeTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/NumericalRangeTest.java
@@ -26,6 +26,34 @@ public class NumericalRangeTest
         assertFalse("above range2", range2.isValueInRange(50.21f));
     }
     
+    @Test(expected = ValueTooHighException.class)
+    public final void testCheckValueTooHighInclusive() throws Exception
+    {
+        final NumericalRange range = new NumericalRange(0.0f, true, 50.0f, true);
+        range.checkValue(50.1f);
+    }
+    
+    @Test(expected = ValueTooHighException.class)
+    public final void testCheckValueTooHighExclusive() throws Exception
+    {
+        final NumericalRange range = new NumericalRange(0.0f, true, 50.0f, false);
+        range.checkValue(50.0f);
+    }
+    
+    @Test(expected = ValueTooLowException.class)
+    public final void testCheckValueTooLowInclusive() throws Exception
+    {
+        final NumericalRange range = new NumericalRange(10.0f, true, 50.0f, true);
+        range.checkValue(9.99f);
+    }
+    
+    @Test(expected = ValueTooLowException.class)
+    public final void testCheckValueTooLowExclusive() throws Exception
+    {
+        final NumericalRange range = new NumericalRange(10.0f, false, 50.0f, true);
+        range.checkValue(10.0f);
+    }
+    
     @Test
     public final void testToString()
     {

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
@@ -247,8 +247,7 @@ public class SampleModels
     {
         final NumericalVariable var = new NumericalVariable(
                 "Age", demographicsVariableGroup(), "age");
-        var.setMinValue(0);
-        var.setMaxValue(999);
+        var.setValidRange(new NumericalRange(0.0f, true, 999.0f, true));
         var.setUnits("years");
         var.setRetriever(RetrievalEnum.AGE);
         return var;
@@ -294,8 +293,7 @@ public class SampleModels
         final List<Category> categories = Arrays.asList(wbcWnl, wbcHigh);
         final DiscreteNumericalVariable var = new DiscreteNumericalVariable(
                 "White Blood Count", labVariableGroup(), new HashSet<>(categories), "wbc");
-        var.setMinValue(2.0f);
-        var.setMaxValue(50.0f);
+        var.setValidRange(new NumericalRange(2.0f, true, 50.0f, true));
         var.setUnits("x1000/mm^3");
         return var;
     }
@@ -321,10 +319,7 @@ public class SampleModels
                 ageGreaterThanEqualToSeventy);
         final DiscreteNumericalVariable var = new DiscreteNumericalVariable("Cardiac Age", demographicsVariableGroup(),
                 new HashSet<>(categories), "cardiacAge");
-        var.setMinValue(18.0f);
-        var.setMinInclusive(true);
-        var.setMaxValue(120.0f);
-        var.setMaxInclusive(true);
+        var.setValidRange(new NumericalRange(18.0f, true, 120.0f, true));
         var.setRetriever(RetrievalEnum.CARDIAC_AGE);
     	
     	return var;
@@ -345,8 +340,7 @@ public class SampleModels
         final List<Category> categories = Arrays.asList(wbcWnl, wbcHigh);
         final DiscreteNumericalVariable var = new DiscreteNumericalVariable(
                 "White Blood Count", labVariableGroup(), new HashSet<>(categories), "wbc");
-        var.setMinValue(2.0f);
-        var.setMaxValue(50.0f);
+        var.setValidRange(new NumericalRange(2.0f, true, 50.0f, true));
         var.setUnits("x1000/mm^3");
         return var;
     }

--- a/srcalc/src/test/resources/sql/insert_base_data.sql
+++ b/srcalc/src/test/resources/sql/insert_base_data.sql
@@ -60,7 +60,7 @@ INSERT INTO RISK_MODEL_PROCEDURE_TERM (risk_model_id, variable, coefficient) VAL
 INSERT INTO VARIABLE (id, display_name, variable_key, retrieval_key, variable_group, help_text) VALUES (2, 'Age', 'age', 1, 2, 'The Patient Age');
 -- There is not really an upper limit on age, but specify an unrealistically high
 -- one to have some idea of significant digits.
-INSERT INTO NUMERICAL_VARIABLE (id, min_value, min_inclusive, max_value, max_inclusive, units) VALUES (2, 18, TRUE, 120, TRUE, 'years');
+INSERT INTO NUMERICAL_VARIABLE (id, lower_bound, lower_inclusive, upper_bound, upper_inclusive, units) VALUES (2, 18, TRUE, 120, TRUE, 'years');
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (1, 2, 2.1);
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (2, 2, 2.2);
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (3, 2, 2.3);
@@ -84,7 +84,7 @@ INSERT INTO RISK_MODEL_BOOLEAN_TERM (risk_model_id, variable, coefficient) VALUE
 INSERT INTO VARIABLE (id, display_name, variable_key, variable_group, help_text) VALUES (5, 'BMI', 'bmi', 3, 'Body Mass Index, deduced by visually examining the patient');
 -- There is not really an upper limit on BMI, but specify an unrealistically high
 -- one to have some idea of significant digits.
-INSERT INTO NUMERICAL_VARIABLE (id, min_value, min_inclusive, max_value, max_inclusive, units) VALUES (5, 0, FALSE, 499, TRUE, '');
+INSERT INTO NUMERICAL_VARIABLE (id, lower_bound, lower_inclusive, upper_bound, upper_inclusive, units) VALUES (5, 0, FALSE, 499, TRUE, '');
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (1, 5, 5.1);
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (2, 5, 5.2);
 INSERT INTO RISK_MODEL_NUMERICAL_TERM (risk_model_id, variable, coefficient) VALUES (3, 5, 5.3);
@@ -114,7 +114,7 @@ INSERT INTO RISK_MODEL_BOOLEAN_TERM (risk_model_id, variable, coefficient) VALUE
 
 -- Alkaline Phosphatase Lab
 INSERT INTO VARIABLE (id, display_name, variable_key, variable_group) VALUES (9, 'Alkaline Phosphatase', 'alkalinePhosphatase', 5);
-INSERT INTO DISCRETE_NUMERICAL_VAR (id, min_value, min_inclusive, max_value, max_inclusive, units) VALUES (9, 10, TRUE, 750, TRUE, 'mU/ml');
+INSERT INTO DISCRETE_NUMERICAL_VAR (id, lower_bound, lower_inclusive, upper_bound, upper_inclusive, units) VALUES (9, 10, TRUE, 750, TRUE, 'mU/ml');
 INSERT INTO DISCRETE_NUMERICAL_VAR_CATEGORY (variable_id, option_value, lower_bound, lower_inclusive, upper_bound, upper_inclusive) VALUES (9, 'WNL', -1e12, TRUE, 125.0, TRUE);
 INSERT INTO DISCRETE_NUMERICAL_VAR_CATEGORY (variable_id, option_value, lower_bound, lower_inclusive, upper_bound, upper_inclusive) VALUES (9, '>125mU/ml', 125.0, FALSE, 1e12, TRUE);
 INSERT INTO RISK_MODEL_DISCRETE_TERM (risk_model_id, variable, option_index, coefficient) VALUES (1, 9, 1, 9.1);
@@ -124,7 +124,7 @@ INSERT INTO RISK_MODEL_DISCRETE_TERM (risk_model_id, variable, option_index, coe
 
 -- BUN Lab
 INSERT INTO VARIABLE (id, display_name, variable_key, variable_group) VALUES (10, 'BUN', 'bun', 5);
-INSERT INTO DISCRETE_NUMERICAL_VAR (id, min_value, min_inclusive, max_value, max_inclusive, units) VALUES (10, 2, TRUE, 90, TRUE, 'mg/dl');
+INSERT INTO DISCRETE_NUMERICAL_VAR (id, lower_bound, lower_inclusive, upper_bound, upper_inclusive, units) VALUES (10, 2, TRUE, 90, TRUE, 'mg/dl');
 INSERT INTO DISCRETE_NUMERICAL_VAR_CATEGORY (variable_id, option_value, lower_bound, lower_inclusive, upper_bound, upper_inclusive) VALUES (10, 'WNL', -1e12, TRUE, 25, TRUE);
 INSERT INTO DISCRETE_NUMERICAL_VAR_CATEGORY (variable_id, option_value, lower_bound, lower_inclusive, upper_bound, upper_inclusive) VALUES (10, '>25mg/dl', 25, FALSE, 1e12, TRUE);
 INSERT INTO RISK_MODEL_DISCRETE_TERM (risk_model_id, variable, option_index, coefficient) VALUES (1, 10, 1, 10.1);


### PR DESCRIPTION
Previously, AbstractNumericalVariable presented various getters and setters for
modifying compnents of the valid range. Internally it modified the
NumericalRange member, which is supposed to be immutable.

This commit tightens up the AbstractNumericalVariable interface by providing a
`getValidRange()` to access the stored NumericalRange and a `setValidRange()` to
completely replace it with another immutable instance.