### PR TITLE
ASRC-10 #2: tighten up Procedure interface

### DIFF
--- a/install/resources/create_database.sql
+++ b/install/resources/create_database.sql
@@ -4,7 +4,7 @@ CREATE DATABASE srcalc;
 USE srcalc;
 
 create table boolean_variable (id integer not null, primary key (id));
-create table cpt (id integer not null auto_increment, complexity varchar(255), cpt_code varchar(255), eligible boolean not null, long_description varchar(255), rvu float not null, short_description varchar(255), primary key (id));
+create table cpt (id integer not null auto_increment, complexity varchar(40) not null, cpt_code varchar(5) not null, eligible boolean not null, long_description varchar(256) not null, rvu float not null, short_description varchar(256) not null, primary key (id));
 create table discrete_numerical_var (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
 create table discrete_numerical_var_category (variable_id integer not null, option_value varchar(80) not null, upper_bound float not null, upper_inclusive boolean not null, primary key (variable_id, option_value, upper_bound, upper_inclusive));
 create table multi_select_variable (display_type varchar(255), id integer not null, primary key (id));

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/Procedure.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/Procedure.java
@@ -1,19 +1,42 @@
 package gov.va.med.srcalc.domain.model;
 
+import gov.va.med.srcalc.util.Preconditions;
+
 import java.util.Objects;
 
 import javax.persistence.*;
 
+import org.hibernate.annotations.Immutable;
+
 /**
- * <p>Represents a medical procedure, particuarly a CPT code.</p>
+ * <p>Represents a medical procedure, particuarly a CPT code. Presents an immutable public
+ * interface.</p>
  * 
  * <p>Per Effective Java Item 17, this class is marked final because it was not
  * designed for inheritance.</p>
  */
 @Entity
 @Table(name="CPT")   // call it CPT because "PROCEDURE" is a SQL reserved word
+@Immutable
 public final class Procedure
 {
+    /**
+     * The length of all CPT codes, {@value}.
+     */
+    public static final int CPT_CODE_LENGTH = 5;
+    
+    /**
+     * The maximum length of both the long and short description, {@value}. See
+     * {@link #getShortDescription() the short description comment} for why this is the
+     * same for both short and long.
+     */
+    public static final int DESCRIPTION_MAX = 256;
+    
+    /**
+     * The maximum length of the complexity string, {@value}.
+     */
+    public static final int COMPLEXITY_MAX = 40;
+    
     private int fId;
     
     private String fCptCode;
@@ -29,13 +52,18 @@ public final class Procedure
     private boolean fEligible;
 
     /**
-     * Package-private default constructor mainly for Hibernate use. Be careful
-     * about using this constructor as the CPT Code must be set for the object
-     * to be in a valid state.
+     * Package-private default constructor intended only for reflection-based
+     * construction.
      */
     Procedure()
     {
+        // Set sentinel values.
         fCptCode = "NOT SET";
+        fRvu = Float.NaN;
+        fShortDescription = "NOT SET";
+        fLongDescription = "NOT SET";
+        fComplexity = "NOT SET";
+        fEligible = false;
     }
     
     /**
@@ -46,14 +74,16 @@ public final class Procedure
             final float rvu,
             final String shortDescription,
             final String longDescription,
-            final String complexity)
+            final String complexity,
+            final boolean eligible)
     {
-        fCptCode = cptCode;
-        fRvu = rvu;
-        fShortDescription = shortDescription;
-        fLongDescription = longDescription;
-        fComplexity = complexity;
-        fEligible = true;
+        // Use setters to verify constraints.
+        setCptCode(cptCode);
+        setRvu(rvu);
+        setShortDescription(shortDescription);
+        setLongDescription(longDescription);
+        setComplexity(complexity);
+        setEligible(eligible);
     }
 
     @Id // We use method-based property detection throughout the app.
@@ -71,21 +101,25 @@ public final class Procedure
         this.fId = id;
     }
 
+    /**
+     * Returns the Procedure's CPT code.
+     * @return a 5-character String
+     */
     @Basic
+    @Column(nullable = false, length = CPT_CODE_LENGTH)
     public String getCptCode()
     {
         return fCptCode;
     }
 
     /**
-     * For reflection-based construction only. The CPT code is this object's
-     * natural identifier and should not be changed. If a Procedure needs a new
-     * CPT code, the existing Procedure should be deactivated and a new one
-     * created.
+     * Sets the CPT code. For reflection-based construction only.
+     * @throws IllegalArgumentException if the given code is not 5 characters long
      */
     void setCptCode(final String cptCode)
     {
-        this.fCptCode = cptCode;
+        this.fCptCode = Preconditions.requireWithin(
+                cptCode, CPT_CODE_LENGTH, CPT_CODE_LENGTH);
     }
 
     /**
@@ -97,42 +131,78 @@ public final class Procedure
         return fRvu;
     }
 
-    public void setRvu(final float rvu)
+    /**
+     * Sets the Relative Value Unit (RVU). For reflection-based construction only.
+     */
+    void setRvu(final float rvu)
     {
         this.fRvu = rvu;
     }
-
-    @Basic
-    public String getShortDescription()
-    {
-    	return fShortDescription;
-    }
-
-    public void setShortDescription(final String description)
-    {
-    	fShortDescription = description;
-    }
     
+    /**
+     * Returns the full procedure description.
+     * @return a String no longer than {@link #DESCRIPTION_MAX} characters
+     */
     @Basic
+    @Column(nullable = false, length = DESCRIPTION_MAX)
     public String getLongDescription()
     {
         return fLongDescription;
     }
 
-    public void setLongDescription(final String longDescription)
+    /**
+     * Sets the full procedure description. For reflection-based construction only.
+     * @throws IllegalArgumentException if the given string is empty or greater than
+     * {@value #DESCRIPTION_MAX} characters
+     */
+    void setLongDescription(final String description)
     {
-        fLongDescription = longDescription;
+        fLongDescription = Preconditions.requireWithin(description, 1, DESCRIPTION_MAX);
+    }
+
+    /**
+     * Returns a shortened version of the procedure description. Some procedures do not
+     * have a shortened description, so the returned String may be equal to {@link
+     * #getLongDescription()}.
+     * @return a String no longer than {@link #DESCRIPTION_MAX} characters
+     */
+    @Basic
+    @Column(nullable = false, length = DESCRIPTION_MAX)
+    public String getShortDescription()
+    {
+    	return fShortDescription;
+    }
+
+    /**
+     * Sets the shortened procedure description. For reflection-based construction only.
+     * @throws IllegalArgumentException if the given string is empty or greater than
+     * {@value #DESCRIPTION_MAX} characters
+     */
+    void setShortDescription(final String description)
+    {
+    	fShortDescription = Preconditions.requireWithin(description, 1, DESCRIPTION_MAX);
     }
     
+    /**
+     * Returns a String describing the procedure's surgical complexity. (This may only
+     * be relevant for the VA.)
+     * @return a String no longer than {@link #COMPLEXITY_MAX} characters
+     */
     @Basic
+    @Column(nullable = false, length = COMPLEXITY_MAX)
     public String getComplexity()
     {
     	return fComplexity;
     }
     
-    public void setComplexity(final String complexity)
+    /**
+     * Sets the surgical complexity string. For reflection-based construction only.
+     * @throws IllegalArgumentException if the given string is empty or greater than
+     * {@value #COMPLEXITY_MAX} characters
+     */
+    void setComplexity(final String complexity)
     {
-    	fComplexity = complexity;
+    	fComplexity = Preconditions.requireWithin(complexity, 1, COMPLEXITY_MAX);
     }
 
     /**
@@ -145,9 +215,10 @@ public final class Procedure
     }
 
     /**
-     * Sets whether this procedure is eligible for a risk calculation.
+     * Sets whether this procedure is eligible for a risk calculation. For
+     * reflection-based construction only.
      */
-    public void setEligible(final boolean eligible)
+    void setEligible(final boolean eligible)
     {
         fEligible = eligible;
     }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/ProcedureTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/ProcedureTest.java
@@ -2,6 +2,7 @@ package gov.va.med.srcalc.domain.model;
 
 import static org.junit.Assert.*;
 import gov.va.med.srcalc.domain.model.Procedure;
+import gov.va.med.srcalc.test.util.TestHelpers;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.junit.Test;
@@ -28,6 +29,49 @@ public class ProcedureTest
     public final void testEquals()
     {
         EqualsVerifier.forClass(Procedure.class).verify();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testCptTooShort()
+    {
+        new Procedure(
+                "1234", 1.0f, "short desc", "long description", "Standard", true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testLongDescTooLong()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                "short desc",
+                TestHelpers.stringOfLength(Procedure.DESCRIPTION_MAX + 1),
+                "Standard",
+                true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testShortDescTooLong()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                TestHelpers.stringOfLength(Procedure.DESCRIPTION_MAX + 1),
+                "long description",
+                "Standard",
+                true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testComplexityTooLong()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                "short desc",
+                "long description",
+                TestHelpers.stringOfLength(Procedure.COMPLEXITY_MAX + 1),
+                true);
     }
     
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/ProcedureTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/ProcedureTest.java
@@ -39,6 +39,25 @@ public class ProcedureTest
     }
     
     @Test(expected = IllegalArgumentException.class)
+    public final void testCptTooLong()
+    {
+        new Procedure(
+                "123456", 1.0f, "short desc", "long description", "Standard", true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testLongDescEmpty()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                "short desc",
+                "",
+                "Standard",
+                true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
     public final void testLongDescTooLong()
     {
         new Procedure(
@@ -46,6 +65,18 @@ public class ProcedureTest
                 1.0f,
                 "short desc",
                 TestHelpers.stringOfLength(Procedure.DESCRIPTION_MAX + 1),
+                "Standard",
+                true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testShortDescEmpty()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                "",
+                "long description",
                 "Standard",
                 true);
     }
@@ -59,6 +90,18 @@ public class ProcedureTest
                 TestHelpers.stringOfLength(Procedure.DESCRIPTION_MAX + 1),
                 "long description",
                 "Standard",
+                true);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testComplexityEmpty()
+    {
+        new Procedure(
+                "1234",
+                1.0f,
+                "short desc",
+                "long description",
+                "",
                 true);
     }
     

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
@@ -9,6 +9,7 @@ import java.util.*;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 
 /**
@@ -23,7 +24,8 @@ public class SampleModels
                 10.06f,
                 "Repair left hand",
                 "Repair left hand - you know, the thing with fingers",
-                "Standard");  
+                "Standard",
+                true);  
     }
 
     public static Procedure repairRightProcedure()
@@ -33,12 +35,16 @@ public class SampleModels
                 5.05f,
                 "Repair right hand",
                 "Repair right hand - you know, the thing with fingers",
-                "Standard");  
+                "Standard",
+                true);  
     }
     
-    public static List<Procedure> procedureList()
+    /**
+     * Returns a List of two dummy procedures, ordered by CPT code.
+     */
+    public static ImmutableList<Procedure> procedureList()
     {
-        return Arrays.asList(repairRightProcedure(), repairLeftProcedure());
+        return ImmutableList.of(repairRightProcedure(), repairLeftProcedure());
     }
     
     /**


### PR DESCRIPTION
Specify and verify constraints on the various attributes and make the public
interface immutable. (The original design intended for administrators to modify
procedures, but this is no longer the case.)