### PR TITLE
ASRC-52: save results upon signature

### DIFF
--- a/install/resources/create_database.sql
+++ b/install/resources/create_database.sql
@@ -7,8 +7,7 @@ create table boolean_variable (id integer not null, primary key (id));
 create table cpt (id integer not null auto_increment, complexity varchar(40) not null, cpt_code varchar(5) not null, eligible boolean not null, long_description varchar(256) not null, rvu float not null, short_description varchar(256) not null, primary key (id));
 create table discrete_numerical_var (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
 create table discrete_numerical_var_category (variable_id integer not null, option_value varchar(80) not null, upper_bound float not null, upper_inclusive boolean not null, primary key (variable_id, option_value, upper_bound, upper_inclusive));
-create table historical_calc (id integer not null auto_increment, seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
-create table historical_calc_person_class (calc_id integer not null, provider_type varchar(80) not null, primary key (calc_id, provider_type));
+create table historical_calc (id integer not null auto_increment, provider_type varchar(80), seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
 create table multi_select_variable (display_type varchar(255), id integer not null, primary key (id));
 create table multi_select_variable_option (variable_id integer not null, option_value varchar(80) not null, option_index integer not null, primary key (variable_id, option_index));
 create table numerical_variable (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
@@ -32,7 +31,6 @@ alter table variable add constraint UK_3on3hwgilp01pjk6iqxarybnm unique (variabl
 alter table boolean_variable add index FK_8s7i3kftdcnt17a8us2sh6qou (id), add constraint FK_8s7i3kftdcnt17a8us2sh6qou foreign key (id) references variable (id);
 alter table discrete_numerical_var add index FK_1hmr3q0o9tn8xd48slnkwk0ld (id), add constraint FK_1hmr3q0o9tn8xd48slnkwk0ld foreign key (id) references variable (id);
 alter table discrete_numerical_var_category add index FK_ai58j7ktbfoadjqgqm0llm11e (variable_id), add constraint FK_ai58j7ktbfoadjqgqm0llm11e foreign key (variable_id) references discrete_numerical_var (id);
-alter table historical_calc_person_class add index FK_3o264tgux2bfssok1welbxabj (calc_id), add constraint FK_3o264tgux2bfssok1welbxabj foreign key (calc_id) references historical_calc (id);
 alter table multi_select_variable add index FK_18hqfsy87bg9ucro7r0h6hl5t (id), add constraint FK_18hqfsy87bg9ucro7r0h6hl5t foreign key (id) references variable (id);
 alter table multi_select_variable_option add index FK_aho8l3stxs2pix74vg19xmman (variable_id), add constraint FK_aho8l3stxs2pix74vg19xmman foreign key (variable_id) references multi_select_variable (id);
 alter table numerical_variable add index FK_ntgiooontcrixh9umumtbf9yh (id), add constraint FK_ntgiooontcrixh9umumtbf9yh foreign key (id) references variable (id);

--- a/install/resources/create_database.sql
+++ b/install/resources/create_database.sql
@@ -7,6 +7,8 @@ create table boolean_variable (id integer not null, primary key (id));
 create table cpt (id integer not null auto_increment, complexity varchar(40) not null, cpt_code varchar(5) not null, eligible boolean not null, long_description varchar(256) not null, rvu float not null, short_description varchar(256) not null, primary key (id));
 create table discrete_numerical_var (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
 create table discrete_numerical_var_category (variable_id integer not null, option_value varchar(80) not null, upper_bound float not null, upper_inclusive boolean not null, primary key (variable_id, option_value, upper_bound, upper_inclusive));
+create table historical_calc (id integer not null auto_increment, seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
+create table historical_calc_person_class (calc_id integer not null, provider_type varchar(80) not null, primary key (calc_id, provider_type));
 create table multi_select_variable (display_type varchar(255), id integer not null, primary key (id));
 create table multi_select_variable_option (variable_id integer not null, option_value varchar(80) not null, option_index integer not null, primary key (variable_id, option_index));
 create table numerical_variable (units varchar(40) not null, lower_bound float not null, lower_inclusive boolean not null, upper_bound float not null, upper_inclusive boolean not null, id integer not null, primary key (id));
@@ -19,6 +21,9 @@ create table risk_model_numerical_term (risk_model_id integer not null, variable
 create table risk_model_procedure_term (risk_model_id integer not null, variable integer not null, coefficient float not null, primary key (risk_model_id, variable, coefficient));
 create table rule (id integer not null auto_increment, bypass_enabled boolean not null, display_name varchar(80) not null, summand_expression varchar(255) not null, primary key (id));
 create table rule_value_matcher (rule_id integer not null, boolean_expression varchar(255), expression_enabled boolean not null, variable integer);
+create table signed_result (run_id integer not null, cpt_code varchar(5), patient_dfn integer not null, signature_timestamp datetime not null, primary key (run_id));
+create table signed_result_input (result_id integer not null, variable_value varchar(255) not null, variable_key varchar(40) not null, primary key (result_id, variable_key));
+create table signed_result_outcome (result_id integer not null, risk_result float not null, model_name varchar(80) not null, primary key (result_id, model_name));
 create table specialty (id integer not null auto_increment, name varchar(100) not null, vista_id integer not null, primary key (id));
 create table specialty_risk_model (specialty_id integer not null, risk_model_id integer not null, primary key (specialty_id, risk_model_id));
 create table variable (id integer not null auto_increment, display_name varchar(80) not null, help_text varchar(4000), variable_key varchar(40) not null, retrieval_key integer, variable_group integer not null, primary key (id));
@@ -27,6 +32,7 @@ alter table variable add constraint UK_3on3hwgilp01pjk6iqxarybnm unique (variabl
 alter table boolean_variable add index FK_8s7i3kftdcnt17a8us2sh6qou (id), add constraint FK_8s7i3kftdcnt17a8us2sh6qou foreign key (id) references variable (id);
 alter table discrete_numerical_var add index FK_1hmr3q0o9tn8xd48slnkwk0ld (id), add constraint FK_1hmr3q0o9tn8xd48slnkwk0ld foreign key (id) references variable (id);
 alter table discrete_numerical_var_category add index FK_ai58j7ktbfoadjqgqm0llm11e (variable_id), add constraint FK_ai58j7ktbfoadjqgqm0llm11e foreign key (variable_id) references discrete_numerical_var (id);
+alter table historical_calc_person_class add index FK_3o264tgux2bfssok1welbxabj (calc_id), add constraint FK_3o264tgux2bfssok1welbxabj foreign key (calc_id) references historical_calc (id);
 alter table multi_select_variable add index FK_18hqfsy87bg9ucro7r0h6hl5t (id), add constraint FK_18hqfsy87bg9ucro7r0h6hl5t foreign key (id) references variable (id);
 alter table multi_select_variable_option add index FK_aho8l3stxs2pix74vg19xmman (variable_id), add constraint FK_aho8l3stxs2pix74vg19xmman foreign key (variable_id) references multi_select_variable (id);
 alter table numerical_variable add index FK_ntgiooontcrixh9umumtbf9yh (id), add constraint FK_ntgiooontcrixh9umumtbf9yh foreign key (id) references variable (id);
@@ -43,6 +49,9 @@ alter table risk_model_procedure_term add index FK_6qew8kqxs6kjujfnjblxpa45c (va
 alter table risk_model_procedure_term add index FK_d3tmxsvauxneoplv06nwqro2j (risk_model_id), add constraint FK_d3tmxsvauxneoplv06nwqro2j foreign key (risk_model_id) references risk_model (id);
 alter table rule_value_matcher add index FK_3hhhc928hdy3o0beed9wjnq9m (variable), add constraint FK_3hhhc928hdy3o0beed9wjnq9m foreign key (variable) references variable (id);
 alter table rule_value_matcher add index FK_rnatr4b2fmd3kx6ff0ka1g4le (rule_id), add constraint FK_rnatr4b2fmd3kx6ff0ka1g4le foreign key (rule_id) references rule (id);
+alter table signed_result add index FK_fbh9rjcin6qo4vi5cyhvqneok (run_id), add constraint FK_fbh9rjcin6qo4vi5cyhvqneok foreign key (run_id) references historical_calc (id);
+alter table signed_result_input add index FK_a7w1dts524sqt755yf1q8igvv (result_id), add constraint FK_a7w1dts524sqt755yf1q8igvv foreign key (result_id) references signed_result (run_id);
+alter table signed_result_outcome add index FK_jbofpapc0i5qoixu28f4ekjm (result_id), add constraint FK_jbofpapc0i5qoixu28f4ekjm foreign key (result_id) references signed_result (run_id);
 alter table specialty_risk_model add index FK_g44r1aagpmd130bpvefwj08ve (risk_model_id), add constraint FK_g44r1aagpmd130bpvefwj08ve foreign key (risk_model_id) references risk_model (id);
 alter table specialty_risk_model add index FK_rrt5htbg4mmbygm2qieptls2q (specialty_id), add constraint FK_rrt5htbg4mmbygm2qieptls2q foreign key (specialty_id) references specialty (id);
 alter table variable add index FK_thvnglkbf1ynftxe54elpdfd7 (variable_group), add constraint FK_thvnglkbf1ynftxe54elpdfd7 foreign key (variable_group) references variable_group (id);

--- a/install/resources/schema_upgrade_0_10.sql
+++ b/install/resources/schema_upgrade_0_10.sql
@@ -2,3 +2,13 @@
 
 alter table specialty_risk_model drop index UK_g44r1aagpmd130bpvefwj08ve;
 
+create table historical_calc (id integer not null auto_increment, seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
+create table historical_calc_person_class (calc_id integer not null, provider_type varchar(80) not null, primary key (calc_id, provider_type));
+alter table historical_calc_person_class add index FK_3o264tgux2bfssok1welbxabj (calc_id), add constraint FK_3o264tgux2bfssok1welbxabj foreign key (calc_id) references historical_calc (id);
+
+create table signed_result (run_id integer not null, cpt_code varchar(5), patient_dfn integer not null, signature_timestamp datetime not null, primary key (run_id));
+create table signed_result_input (result_id integer not null, variable_value varchar(255) not null, variable_key varchar(40) not null, primary key (result_id, variable_key));
+create table signed_result_outcome (result_id integer not null, risk_result float not null, model_name varchar(80) not null, primary key (result_id, model_name));
+alter table signed_result add index FK_fbh9rjcin6qo4vi5cyhvqneok (run_id), add constraint FK_fbh9rjcin6qo4vi5cyhvqneok foreign key (run_id) references historical_calc (id);
+alter table signed_result_input add index FK_a7w1dts524sqt755yf1q8igvv (result_id), add constraint FK_a7w1dts524sqt755yf1q8igvv foreign key (result_id) references signed_result (run_id);
+alter table signed_result_outcome add index FK_jbofpapc0i5qoixu28f4ekjm (result_id), add constraint FK_jbofpapc0i5qoixu28f4ekjm foreign key (result_id) references signed_result (run_id);

--- a/install/resources/schema_upgrade_0_10.sql
+++ b/install/resources/schema_upgrade_0_10.sql
@@ -2,9 +2,7 @@
 
 alter table specialty_risk_model drop index UK_g44r1aagpmd130bpvefwj08ve;
 
-create table historical_calc (id integer not null auto_increment, seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
-create table historical_calc_person_class (calc_id integer not null, provider_type varchar(80) not null, primary key (calc_id, provider_type));
-alter table historical_calc_person_class add index FK_3o264tgux2bfssok1welbxabj (calc_id), add constraint FK_3o264tgux2bfssok1welbxabj foreign key (calc_id) references historical_calc (id);
+create table historical_calc (id integer not null auto_increment, provider_type varchar(80), seconds_to_first_run integer not null, specialty_name varchar(100) not null, start_timestamp datetime not null, user_station varchar(10) not null, primary key (id));
 
 create table signed_result (run_id integer not null, cpt_code varchar(5), patient_dfn integer not null, signature_timestamp datetime not null, primary key (run_id));
 create table signed_result_input (result_id integer not null, variable_value varchar(255) not null, variable_key varchar(40) not null, primary key (result_id, variable_key));

--- a/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
@@ -1,0 +1,61 @@
+package gov.va.med.srcalc.db;
+
+import javax.inject.Inject;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+import gov.va.med.srcalc.domain.calculation.HistoricalCalculation;
+import gov.va.med.srcalc.domain.calculation.SignedResult;
+
+/**
+ * Data Access Object (DAO) for {@link HistoricalCalculation}s and {@link SignedResult}s.
+ */
+@Repository
+public class ResultsDao
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResultsDao.class);
+    
+    private final SessionFactory fSessionFactory;
+    
+    @Inject
+    public ResultsDao(final SessionFactory sessionFactory)
+    {
+        fSessionFactory = sessionFactory;
+    }
+    
+    protected Session getCurrentSession()
+    {
+        return fSessionFactory.getCurrentSession();
+    }
+    
+    /**
+     * Persists the given new (aka transient) {@link HistoricalCalculation}. Note that
+     * this method does not support updating an already-persistent object (because
+     * they are immutable).
+     * @param calc the object to persist
+     * @throws HibernateException if the given object is already persistent
+     */
+    public void persistHistoricalCalc(final HistoricalCalculation calc)
+    {
+        LOGGER.debug("Persisting new HistoricalCalculation: {}", calc);
+        getCurrentSession().persist(calc);
+    }
+    
+    /**
+     * Persists the given new (aka transient) SignedResult. Note that this method does not
+     * support updating an already-persistent object (because they are immutable).
+     * @param result the object to persist
+     * @throws HibernateException if the given object is already persistent
+     */
+    public void persistSignedResult(final SignedResult result)
+    {
+        LOGGER.debug("Persisting new SignedResult: {}", result);
+        getCurrentSession().persist(result);
+    }
+    
+}

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/VistaPerson.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/VistaPerson.java
@@ -1,42 +1,47 @@
 package gov.va.med.srcalc.domain;
 
+import java.util.Set;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
+
 /**
  * A VistA person (from the NEW PERSON file).
  */
 public class VistaPerson
 {
-    private final String fDivision;
+    private final String fStationNumber;
     private final String fDuz;
     private final String fDisplayName;
-    private final String fUserClass;
+    private final ImmutableSet<String> fProviderTypes;
     
     /**
      * Constructs an instance.
-     * @param division See {@link #getDivision()}.
+     * @param stationNumber See {@link #getStationNumber()}.
      * @param duz See {@link #getDuz()}.
-     * @param displayName
-     * @param userClass
+     * @param displayName See {@link #getDisplayName()}.
+     * @param providerTypes See {@link #getProviderTypes()}.
      */
     public VistaPerson(
-            final String division,
+            final String stationNumber,
             final String duz,
             final String displayName,
-            final String userClass)
+            final Set<String> providerTypes)
     {
-        fDivision = division;
+        fStationNumber = stationNumber;
         fDuz = duz;
         fDisplayName = displayName;
-        fUserClass = userClass;
+        fProviderTypes = ImmutableSet.copyOf(providerTypes);
     }
 
     /**
-     * The user's currently logged-in division. Note that a single VistA user
-     * (NEW PERSON) may be associated with multiple divisions, but we only track
-     * the current one.
+     * Identifies the user's currently logged-in division. Note that a single VistA user
+     * (NEW PERSON) may be associated with multiple divisions, but we only track the
+     * current one.
      */
-    public String getDivision()
+    public String getStationNumber()
     {
-        return fDivision;
+        return fStationNumber;
     }
 
     /**
@@ -47,19 +52,35 @@ public class VistaPerson
         return fDuz;
     }
 
+    /**
+     * Returns the user's name as stored in VistA. Typically "LAST,FIRST".
+     */
     public String getDisplayName()
     {
         return fDisplayName;
     }
 
-    public String getUserClass()
+    /**
+     * Returns the user's provider types, from their "Person Classes". Presumably only
+     * clinical staff will have these.
+     */
+    public ImmutableSet<String> getProviderTypes()
     {
-        return fUserClass;
+        return fProviderTypes;
     }
     
+    /**
+     * A String representation of this object. The exact format is unspecified, but it
+     * will at least contain the DUZ, stationNumber, and displayName.
+     */
     @Override
     public String toString()
     {
-        return String.format("%s (%s@%s)", fDisplayName, fDuz, fDivision);
+        return MoreObjects.toStringHelper(this)
+                .add("duz", fDuz)
+                .add("stationNumber", fStationNumber)
+                .add("displayName", fDisplayName)
+                .add("providerTypes", fProviderTypes)
+                .toString();
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/VistaPerson.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/VistaPerson.java
@@ -1,9 +1,7 @@
 package gov.va.med.srcalc.domain;
 
-import java.util.Set;
-
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
 
 /**
  * A VistA person (from the NEW PERSON file).
@@ -13,25 +11,25 @@ public class VistaPerson
     private final String fStationNumber;
     private final String fDuz;
     private final String fDisplayName;
-    private final ImmutableSet<String> fProviderTypes;
+    private final Optional<String> fProviderType;
     
     /**
      * Constructs an instance.
      * @param stationNumber See {@link #getStationNumber()}.
      * @param duz See {@link #getDuz()}.
      * @param displayName See {@link #getDisplayName()}.
-     * @param providerTypes See {@link #getProviderTypes()}.
+     * @param providerType See {@link #getProviderType()}.
      */
     public VistaPerson(
             final String stationNumber,
             final String duz,
             final String displayName,
-            final Set<String> providerTypes)
+            final Optional<String> providerType)
     {
         fStationNumber = stationNumber;
         fDuz = duz;
         fDisplayName = displayName;
-        fProviderTypes = ImmutableSet.copyOf(providerTypes);
+        fProviderType = providerType;
     }
 
     /**
@@ -61,12 +59,12 @@ public class VistaPerson
     }
 
     /**
-     * Returns the user's provider types, from their "Person Classes". Presumably only
+     * Returns the user's provider type, from their "Person Class". Presumably only
      * clinical staff will have these.
      */
-    public ImmutableSet<String> getProviderTypes()
+    public Optional<String> getProviderType()
     {
-        return fProviderTypes;
+        return fProviderType;
     }
     
     /**
@@ -80,7 +78,7 @@ public class VistaPerson
                 .add("duz", fDuz)
                 .add("stationNumber", fStationNumber)
                 .add("displayName", fDisplayName)
-                .add("providerTypes", fProviderTypes)
+                .add("providerType", fProviderType)
                 .toString();
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/Calculation.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/Calculation.java
@@ -2,6 +2,7 @@ package gov.va.med.srcalc.domain.calculation;
 
 import gov.va.med.srcalc.ConfigurationException;
 import gov.va.med.srcalc.domain.Patient;
+import gov.va.med.srcalc.domain.VistaPerson;
 import gov.va.med.srcalc.domain.model.*;
 import gov.va.med.srcalc.util.MissingValuesException;
 
@@ -9,15 +10,18 @@ import java.io.Serializable;
 import java.util.*;
 
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
 
 /**
  * <p>A risk calculation. You can think of this as a step-by-step builder of
  * {@link CalculationResult} objects: set the patient, specialty, etc., and then
- * call {@link #calculate(Collection)} to produce the results.</p>
+ * call {@link #calculate(Collection, VistaPerson)} to produce the results.</p>
  * 
  * <p>A stateful builder such as this (as opposed to a one-shot <code>calculate()</code>
  * which could take all of the necessary data) allows features such as tracking
@@ -33,18 +37,19 @@ public class Calculation implements Serializable
      */
     private static final long serialVersionUID = 1L;
 
-    private DateTime fStartDateTime;
+    private final DateTime fStartDateTime;
     private Patient fPatient;
     private Specialty fSpecialty;
+    private Optional<HistoricalCalculation> fHistoricalCalculation;
     
     /**
-     * This class presents a pure JavaBean interface, with a default constructor
-     * and mutators for all fields. It also offers convenience factory methods
-     * below.
+     * This class presents a pure JavaBean interface, with a default constructor and
+     * mutators for fields. It also offers convenience factory methods below.
      */
     public Calculation()
     {
-        fStartDateTime = new DateTime();
+        fStartDateTime = DateTime.now();
+        fHistoricalCalculation = Optional.absent();
     }
     
     public static Calculation forPatient(final Patient patient)
@@ -196,11 +201,15 @@ public class Calculation implements Serializable
 
     /**
      * Runs the calculation for each outcome with the given Values.
+     * @param values the variable values as inputs to the calculation
+     * @param user the user running the calculation
+     * @return the results as a CalculationResult object
      * @throws IllegalArgumentException if incomplete values are provided
-     * @return the outcomes for convenience
      * @throws MissingValuesException if there are any required variables without an assigned value
      */
-    public CalculationResult calculate(final Collection<Value> values) throws MissingValuesException
+    public CalculationResult calculate(
+            final Collection<Value> values, final VistaPerson user)
+            throws MissingValuesException
     {
         // Run the calculation first to make sure we don't get any exceptions.
         final TreeMap<String, Float> outcomes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -224,12 +233,64 @@ public class Calculation implements Serializable
             throw new MissingValuesException("The calculation is missing values.", missingValues);
         }
         
-        return new CalculationResult(
-                fStartDateTime,
+        final DateTime resultTime = DateTime.now();
+        
+        // If this was the first run, record the HistoricalCalculation for
+        // getHistoricalCalculation().
+        if (!fHistoricalCalculation.isPresent())
+        {
+            final HistoricalCalculation hc = makeHistoricalCalculation(resultTime, user);
+            fHistoricalCalculation = Optional.of(hc);
+            LOGGER.debug("Captured historical information: {}", hc);
+        }
+        
+        final CalculationResult result = new CalculationResult(
+                // This is guaranteed to be set now.
+                fHistoricalCalculation.get(),
                 fPatient.getDfn(),
-                fSpecialty.getName(),
+                resultTime,
                 // The constructor requires a Set, not just a Collection.
                 ImmutableSet.copyOf(values),
                 outcomes);
+        
+        return result;
+    }
+    
+    /**
+     * Constructs a HistoricalCalculation object from this Calculation, given the
+     * timestamp of the first result.
+     * @param firstResultTime the timestamp of the first result, to derive
+     * secondsToFirstResult
+     * @param user the user running the calculation
+     * @return a new HistoricalCalculation
+     * @throws NullPointerException if any argument is null
+     */
+    private HistoricalCalculation makeHistoricalCalculation(
+            final DateTime firstResultTime, final VistaPerson user)
+    {
+        Objects.requireNonNull(firstResultTime);
+        Objects.requireNonNull(user);
+
+        final Duration durationToResult = new Duration(fStartDateTime, firstResultTime);
+        // It is extremely unlikely that this number of seconds will exceed
+        // Integer.MAX_VALUE, but this checked cast will throw an IllegalArgumentException
+        // if so.
+        final int secondsToResult = Ints.checkedCast(durationToResult.getStandardSeconds());
+        return new HistoricalCalculation(
+                fSpecialty.getName(),
+                user.getStationNumber(),
+                fStartDateTime,
+                secondsToResult,
+                user.getProviderTypes());
+    }
+    
+    /**
+     * If {@link #calculate(Collection, VistaPerson)} has been called, returns the {@link
+     * HistoricalCalculation} object encapsulating historical data about this calculation.
+     * @return the HistoricalCalculation (same instance every time), if it exists
+     */
+    public Optional<HistoricalCalculation> getHistoricalCalculation()
+    {
+        return fHistoricalCalculation;
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/Calculation.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/Calculation.java
@@ -281,7 +281,7 @@ public class Calculation implements Serializable
                 user.getStationNumber(),
                 fStartDateTime,
                 secondsToResult,
-                user.getProviderTypes());
+                user.getProviderType());
     }
     
     /**

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
@@ -212,8 +212,8 @@ public final class HistoricalCalculation implements Serializable
     }
     
     /**
-     * As {@link #getProviderType()}, but represents a missing Provider Type as null.
-     * Purely to support Hibernate, which does not support Guava's Optional class.
+     * Similar to {@link #getProviderType()}, but represents a missing Provider Type as
+     * null. Purely to support Hibernate, which does not support Guava's Optional class.
      * @return the optional Provider Type as a nullable string
      */
     @Basic

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
@@ -1,0 +1,264 @@
+package gov.va.med.srcalc.domain.calculation;
+
+import gov.va.med.srcalc.domain.VistaPerson;
+import gov.va.med.srcalc.domain.model.Specialty;
+import gov.va.med.srcalc.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.Immutable;
+import org.joda.time.DateTime;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * <p>Encapsulates data from a past calculation. Stores calculation metadata (division,
+ * specialty name, etc.), but does not store the actual risk results. Unlike {@link
+ * CalculationResult}, this class stores its data as primitive values and is suitable for
+ * storing in a database.</p>
+ * 
+ * <p>This class presents an immutable public interface.</p>
+ *
+ * <p>Per Effective Java Item 17, this class is marked final because it was not
+ * designed for inheritance.</p>
+ */
+@Entity
+@Table(name = "historical_calc") // shorten for the sake of the schema
+@Immutable
+public final class HistoricalCalculation implements Serializable
+{
+    /**
+     * Change this when changing the class!
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The maximum length of a station number String, e.g. {@link #getUserStation()}.
+     */
+    public static final int STATION_NUMBER_MAX = 10;
+    
+    /**
+     * The maximum length of a user class String. VistA's maximum appears to be 30.
+     */
+    public static final int USER_CLASS_MAX = 80;
+
+    private int fId;
+    private String fSpecialtyName;
+    private String fUserStation;
+    private Date fStartTimestamp;
+    private int fSecondsToFirstRun;
+    private ImmutableSet<String> fProviderTypes;
+    
+    /**
+     * Intended for reflection-based construction only. Business code should use the other
+     * constructor.
+     */
+    HistoricalCalculation()
+    {
+    }
+    
+    /**
+     * Constructs an instance with the given properties.
+     * @param specialtyName see {@link #getSpecialtyName()}
+     * @param providerStation see {@link #getUserStation()}
+     * @param secondsToFirstRun see {@link #getSecondsToFirstRun()}
+     * @param providerTypes see {@link #getProviderTypes()}. Defensively-copied.
+     */
+    public HistoricalCalculation(
+            final String specialtyName,
+            final String providerStation,
+            final DateTime startTimestamp,
+            final int secondsToFirstRun,
+            final Set<String> providerTypes)
+    {
+        // Use setters to verify constraints.
+        setSpecialtyName(specialtyName);
+        fUserStation = providerStation;
+        // See getStartTimetsamp() for why we enforce 0 millis of second.
+        fStartTimestamp = startTimestamp.withMillisOfSecond(0).toDate();
+        fSecondsToFirstRun = secondsToFirstRun;
+        fProviderTypes = ImmutableSet.copyOf(providerTypes);
+    }
+    
+    /**
+     * The object's surrogate primary key. Don't show this to the user.
+     */
+    @Id
+    @GeneratedValue
+    public int getId()
+    {
+        return fId;
+    }
+
+    /**
+     * For reflection-based construction only. Business code should never modify
+     * the surrogate key as it is generated from the database.
+     */
+    void setId(final int id)
+    {
+        fId = id;
+    }
+
+    /**
+     * Returns the name of the associated surgical specialty.
+     */
+    @Basic
+    @Column(nullable = false, length = Specialty.SPECIALTY_NAME_MAX)
+    public String getSpecialtyName()
+    {
+        return fSpecialtyName;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setSpecialtyName(final String specialtyName)
+    {
+        fSpecialtyName = Preconditions.requireWithin(
+                specialtyName, 1, Specialty.SPECIALTY_NAME_MAX);
+    }
+
+    /**
+     * Returns the station number of the user who performed the calculation. At time
+     * of writing, this is always the patient's station number as well.
+     * @return never null
+     */
+    @Basic
+    @Column(nullable = false, length = STATION_NUMBER_MAX)
+    public String getUserStation()
+    {
+        return fUserStation;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setUserStation(final String station)
+    {
+        fUserStation = Preconditions.requireWithin(station, 1, STATION_NUMBER_MAX);
+    }
+    
+    /**
+     * Returns when the user started the calculation. We do not track milliseconds, so
+     * this Date object will always represent a particular second on-the-dot.
+     */
+    @Basic
+    @Column(nullable = false)
+    public Date getStartTimestamp()
+    {
+        return fStartTimestamp;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setStartTimestamp(final Date dateTime)
+    {
+        fStartTimestamp = Objects.requireNonNull(dateTime);
+    }
+
+    /**
+     * Returns the number of seconds from when the user first started the calculation to
+     * when he first ran the calculation (i.e., when he first saw the results).
+     */
+    @Basic
+    public int getSecondsToFirstRun()
+    {
+        return fSecondsToFirstRun;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setSecondsToFirstRun(int seconds)
+    {
+        fSecondsToFirstRun = seconds;
+    }
+
+    /**
+     * Returns the Provider Types of the user who performed the calculation.
+     * @return an ImmutableSet
+     * @see VistaPerson#getProviderTypes()
+     */
+    @ElementCollection(fetch = FetchType.EAGER) // eager due to close association
+    // Override strange default column names.
+    @CollectionTable(
+            // Call the table "person_class" in case we ever add other person class fields
+            name = "historical_calc_person_class",
+            joinColumns = @JoinColumn(name = "calc_id"))
+    @Column(name = "provider_type", nullable = false, length = USER_CLASS_MAX)
+    // Hibernate requires us to return a Set instead of an ImmutableSet.
+    public Set<String> getProviderTypes()
+    {
+        return fProviderTypes;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setProviderTypes(final Set<String> providerTypes)
+    {
+        // Note: normally with Hibernate we would preserve the passed collection since it
+        // will be Hibernate's special implementation of Set. Since this object is
+        // immutable, however, we don't care to keep Hibernate's mutable implementation
+        // and just discard it.
+        fProviderTypes = ImmutableSet.copyOf(providerTypes);
+    }
+    
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("specialtyName", fSpecialtyName)
+                .add("start", fStartTimestamp)
+                .add("secondsToFirstRun", fSecondsToFirstRun)
+                .add("userStation", fUserStation)
+                .add("providerTypes", fProviderTypes)
+                .toString();
+    }
+    
+    /**
+     * Implements value equality for all properties.
+     */
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (o instanceof HistoricalCalculation) // returns false for null
+        {
+            final HistoricalCalculation other = (HistoricalCalculation)o;
+            
+            return Objects.equals(this.fSpecialtyName, other.fSpecialtyName) &&
+                    Objects.equals(this.fUserStation, other.fUserStation) &&
+                    Objects.equals(this.fStartTimestamp, other.fStartTimestamp) &&
+                    (this.fSecondsToFirstRun == other.fSecondsToFirstRun) &&
+                    Objects.equals(this.fProviderTypes, other.fProviderTypes);
+        }
+        else
+        {
+            return false;
+        }
+    }
+    
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                fSpecialtyName,
+                fUserStation,
+                fStartTimestamp,
+                fSecondsToFirstRun,
+                fProviderTypes);
+    }
+
+}

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
@@ -1,8 +1,17 @@
 package gov.va.med.srcalc.domain.calculation;
 
+import gov.va.med.srcalc.domain.model.Procedure;
+import gov.va.med.srcalc.domain.model.Variable;
+import gov.va.med.srcalc.util.DisplayNameConditions;
+import gov.va.med.srcalc.util.Preconditions;
+
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.persistence.*;
+
+import org.hibernate.annotations.Immutable;
 import org.joda.time.DateTime;
 
 import com.google.common.base.MoreObjects;
@@ -10,7 +19,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * <p>Represents a signed, totally-immutable calculation result.</p>
+ * <p>Represents a signed, immutable calculation result.</p>
  * 
  * <p>This class is similar to {@link CalculationResult} but stores only primitive
  * values and is suitable for storing in a database.</p>
@@ -18,96 +27,239 @@ import com.google.common.collect.ImmutableMap;
  * <p>Per Effective Java Item 17, this class is marked final because it was not
  * designed for inheritance.</p>
  */
+@Entity
+@Immutable
 public final class SignedResult
 {
-    private final int fPatientDfn;
-    private final String fSpecialtyName;
-    private final Optional<String> fCptCode;
-    private final DateTime fStartDateTime;
-    private final DateTime fSignatureDateTime;
-    private final ImmutableMap<String, Float> fOutcomes;
+    private int fId;
+    private HistoricalCalculation fHistoricalCalculation;
+    private int fPatientDfn;
+    private Optional<String> fCptCode;
+    private Date fSignatureTimestamp;
+    private ImmutableMap<String, String> fInputs;
+    private ImmutableMap<String, Float> fOutcomes;
     
+    /**
+     * Constructs an instance with the given properties.
+     * @param historicalCalc See {@link #getHistoricalCalculation()}.
+     * @param patientDfn See {@link #getPatientDfn()}.
+     * @param cptCode See {@link #getCptCode()}.
+     * @param signatureTimestamp See {@link #getSignatureTimestamp()}.
+     * @param inputs See {@link #getInputs()}.
+     * @param outcomes See {@link #getOutcomes()}.
+     * @throws NullPointerException if any argument is null
+     * @throws IllegalArgumentException if the CPT code is present and not {@link
+     * Procedure#CPT_CODE_LENGTH} characters
+     */
     public SignedResult(
+            final HistoricalCalculation historicalCalc,
             final int patientDfn,
-            final String specialtyName,
             final Optional<String> cptCode,
-            final DateTime startDateTime,
-            final DateTime signatureDateTime,
+            final DateTime signatureTimestamp,
+            final Map<String, String> inputs,
             final Map<String, Float> outcomes)
     {
-        fPatientDfn = patientDfn;
-        fSpecialtyName = specialtyName;
-        fCptCode = cptCode;
-        // See getStartDateTime().
-        fStartDateTime = startDateTime.withMillisOfSecond(0);
-        // See getSignatureDateTime().
-        fSignatureDateTime = signatureDateTime.withMillisOfSecond(0);
-        fOutcomes = ImmutableMap.copyOf(outcomes);
+        // Use setters to verify constraints.
+        setHistoricalCalculation(historicalCalc);
+        setPatientDfn(patientDfn);
+        setCptCodeNullable(cptCode.orNull());
+        // See getSignatureTimestamp() for why we enforce 0 millis of second.
+        setSignatureTimestamp(signatureTimestamp.withMillisOfSecond(0).toDate());
+        setInputs(ImmutableMap.copyOf(inputs));
+        setOutcomes(ImmutableMap.copyOf(outcomes));
     }
     
     /**
+     * The object's surrogate primary key. Don't show this to the user.
+     */
+    @Id
+    public int getId()
+    {
+        return fId;
+    }
+
+    /**
+     * For reflection-based construction only. Business code should never modify
+     * the surrogate key as it is generated from the database.
+     */
+    void setId(final int id)
+    {
+        fId = id;
+    }
+    
+    /**
+     * Returns the associated historical calculation information.
+     * @return never null
+     */
+    @OneToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "run_id")
+    @MapsId
+    public HistoricalCalculation getHistoricalCalculation()
+    {
+        return fHistoricalCalculation;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setHistoricalCalculation(final HistoricalCalculation historicalCalc)
+    {
+        fHistoricalCalculation = Objects.requireNonNull(historicalCalc);
+    }
+
+    /**
      * Returns the DFN of the associated patient.
      */
+    @Basic
     public int getPatientDfn()
     {
         return fPatientDfn;
     }
-
+    
     /**
-     * Returns the name of the associated surgical specialty.
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
      */
-    public String getSpecialtyName()
+    void setPatientDfn(final int patientDfn)
     {
-        return fSpecialtyName;
+        fPatientDfn = patientDfn;
     }
     
     /**
      * Returns the CPT code of the associated procedure, if there was one.
      * @return an Optional containing the CPT code, if applicable
      */
+    @Transient  // Hibernate uses getCptCodeNullabe() instead
     public Optional<String> getCptCode()
     {
         return fCptCode;
     }
     
     /**
-     * The DateTime at which the user started the calculation. We do not track
-     * milliseconds, so the millisOfSecond field will always be 0 to facilitate
-     * comparisons.
+     * As {@link #getCptCode()}, but represents a missing CPT Code as null. Purely to
+     * support Hibernate, which does not support Guava's Optional class.
+     * @return the optional CPT Code as a nullable string
      */
-    public DateTime getStartDateTime()
+    @Column(name = "cpt_code", nullable = true, length = Procedure.CPT_CODE_LENGTH)
+    String getCptCodeNullable()
     {
-        return fStartDateTime;
+        return fCptCode.orNull();
     }
     
     /**
-     * The DateTime at which the user signed the calculation. We do not track
-     * milliseconds, so the millisOfSecond field will always be 0 to facilitate
-     * comparisons.
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     * @throws IllegalArgumentException if the cptCode is not {@link
+     * Procedure#CPT_CODE_LENGTH} characters
      */
-    public DateTime getSignatureDateTime()
+    void setCptCodeNullable(final String cptCode)
     {
-        return fSignatureDateTime;
+        fCptCode = Optional.fromNullable(cptCode);
+        
+        if (fCptCode.isPresent())
+        {
+            Preconditions.requireWithin(
+                    fCptCode.get(), Procedure.CPT_CODE_LENGTH, Procedure.CPT_CODE_LENGTH);
+        }
+    }
+    
+    /**
+     * Returns when the user signed the calculation. We do not track milliseconds, so this
+     * Date object will always represent a particular second on-the-dot.
+     */
+    @Basic
+    @Column(nullable = false)
+    public Date getSignatureTimestamp()
+    {
+        return fSignatureTimestamp;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setSignatureTimestamp(final Date signatureTimestamp)
+    {
+        fSignatureTimestamp = Objects.requireNonNull(signatureTimestamp);
+    }
+    
+    /**
+     * Returns the calculation input values as a Map from variable key to value.
+     * @return an immutable map
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    // Override various defaults for a better schema.
+    @CollectionTable(
+            name = "signed_result_input",
+            joinColumns = @JoinColumn(name = "result_id"))
+    @MapKeyColumn(name = "variable_key", nullable = false, length = Variable.KEY_MAX)
+    // There is no set maximum length for the value string, but the default of 255 should
+    // be sufficient.
+    @Column(name = "variable_value", nullable = false)
+    public Map<String, String> getInputs()
+    {
+        return fInputs;
+    }
+    
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setInputs(final Map<String, String> inputs)
+    {
+        // Note: normally with Hibernate we would preserve the passed collection since it
+        // will be Hibernate's special implementation of Map. Since this object is
+        // immutable, however, we don't care to keep Hibernate's mutable implementation
+        // and just discard it.
+        fInputs = ImmutableMap.copyOf(inputs);
     }
     
     /**
      * Returns the risk outcomes as a Map from risk model name to calculated
      * risk.
+     * @return an immutable map
      */
-    public ImmutableMap<String, Float> getOutcomes()
+    @ElementCollection(fetch = FetchType.EAGER)
+    // Override various defaults for a better schema.
+    @CollectionTable(
+            name = "signed_result_outcome",
+            joinColumns = @JoinColumn(name = "result_id"))
+    @MapKeyColumn(
+            name = "model_name",
+            nullable = false,
+            length = DisplayNameConditions.DISPLAY_NAME_MAX)
+    @Column(name = "risk_result", nullable = false)
+    public Map<String, Float> getOutcomes()
     {
         return fOutcomes;
     }
     
+    /**
+     * For reflection-based construction only. Business code must provide this value to
+     * the constructor.
+     */
+    void setOutcomes(final Map<String, Float> outcomes)
+    {
+        // See note on setValues() above.
+        fOutcomes = ImmutableMap.copyOf(outcomes);
+    }
+    
+    /**
+     * <p>Returns a string representation of this object.</p>
+     * 
+     * <p>The exact format is unspecified, but the string will contain the patientDfn,
+     * cptCode, and {@link HistoricalCalculation#toString()}.</p>
+     */
     @Override
     public String toString()
     {
         return MoreObjects.toStringHelper(this)
+                .add("historicalCalc", fHistoricalCalculation)
                 .add("patientDfn", fPatientDfn)
-                .add("specialty", fSpecialtyName)
                 .add("cptCode", fCptCode)
-                .add("start", fStartDateTime)
-                .add("signed", fSignatureDateTime)
+                .add("outcomes", fOutcomes)
+                .add("signed", fSignatureTimestamp)
                 .toString();
     }
     
@@ -118,11 +270,11 @@ public final class SignedResult
         {
             final SignedResult other = (SignedResult)o;
             
-            return (this.fPatientDfn == other.fPatientDfn) &&
-                    Objects.equals(this.fSpecialtyName, other.fSpecialtyName) &&
+            return Objects.equals(this.fHistoricalCalculation, other.fHistoricalCalculation) &&
+                    (this.fPatientDfn == other.fPatientDfn) &&
                     Objects.equals(this.fCptCode, other.fCptCode) &&
-                    Objects.equals(this.fStartDateTime, other.fStartDateTime) &&
-                    Objects.equals(this.fSignatureDateTime, other.fSignatureDateTime) &&
+                    Objects.equals(this.fSignatureTimestamp, other.fSignatureTimestamp) &&
+                    Objects.equals(this.fInputs, other.fInputs) &&
                     Objects.equals(this.fOutcomes, other.fOutcomes);
         }
         else
@@ -135,11 +287,11 @@ public final class SignedResult
     public int hashCode()
     {
         return Objects.hash(
+                fHistoricalCalculation,
                 fPatientDfn,
-                fSpecialtyName,
                 fCptCode,
-                fStartDateTime,
-                fSignatureDateTime,
+                fSignatureTimestamp,
+                fInputs,
                 fOutcomes);
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
@@ -40,6 +40,14 @@ public final class SignedResult
     private ImmutableMap<String, Float> fOutcomes;
     
     /**
+     * Intended for reflection-based construction only. Business code should use the other
+     * constructor.
+     */
+    SignedResult()
+    {
+    }
+    
+    /**
      * Constructs an instance with the given properties.
      * @param historicalCalc See {@link #getHistoricalCalculation()}.
      * @param patientDfn See {@link #getPatientDfn()}.
@@ -62,7 +70,7 @@ public final class SignedResult
         // Use setters to verify constraints.
         setHistoricalCalculation(historicalCalc);
         setPatientDfn(patientDfn);
-        setCptCodeNullable(cptCode.orNull());
+        setCptCode(cptCode);
         // See getSignatureTimestamp() for why we enforce 0 millis of second.
         setSignatureTimestamp(signatureTimestamp.withMillisOfSecond(0).toDate());
         setInputs(ImmutableMap.copyOf(inputs));
@@ -137,6 +145,22 @@ public final class SignedResult
     }
     
     /**
+     * Sets the cptCode, checking preconditions.
+     * @throws IllegalArgumentException if the cptCode is not {@link
+     * Procedure#CPT_CODE_LENGTH} characters
+     */
+    private void setCptCode(final Optional<String> optional)
+    {
+        if (optional.isPresent())
+        {
+            Preconditions.requireWithin(
+                    optional.get(), Procedure.CPT_CODE_LENGTH, Procedure.CPT_CODE_LENGTH);
+        }
+
+        fCptCode = optional;
+    }
+    
+    /**
      * As {@link #getCptCode()}, but represents a missing CPT Code as null. Purely to
      * support Hibernate, which does not support Guava's Optional class.
      * @return the optional CPT Code as a nullable string
@@ -155,13 +179,7 @@ public final class SignedResult
      */
     void setCptCodeNullable(final String cptCode)
     {
-        fCptCode = Optional.fromNullable(cptCode);
-        
-        if (fCptCode.isPresent())
-        {
-            Preconditions.requireWithin(
-                    fCptCode.get(), Procedure.CPT_CODE_LENGTH, Procedure.CPT_CODE_LENGTH);
-        }
+        setCptCode(Optional.fromNullable(cptCode));
     }
     
     /**

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
@@ -73,8 +73,8 @@ public final class SignedResult
         setCptCode(cptCode);
         // See getSignatureTimestamp() for why we enforce 0 millis of second.
         setSignatureTimestamp(signatureTimestamp.withMillisOfSecond(0).toDate());
-        setInputs(ImmutableMap.copyOf(inputs));
-        setOutcomes(ImmutableMap.copyOf(outcomes));
+        setInputs(inputs);
+        setOutcomes(outcomes);
     }
     
     /**
@@ -161,8 +161,8 @@ public final class SignedResult
     }
     
     /**
-     * As {@link #getCptCode()}, but represents a missing CPT Code as null. Purely to
-     * support Hibernate, which does not support Guava's Optional class.
+     * Similar to {@link #getCptCode()}, but represents a missing CPT Code as null. Purely
+     * to support Hibernate, which does not support Guava's Optional class.
      * @return the optional CPT Code as a nullable string
      */
     @Column(name = "cpt_code", nullable = true, length = Procedure.CPT_CODE_LENGTH)
@@ -223,6 +223,7 @@ public final class SignedResult
     /**
      * For reflection-based construction only. Business code must provide this value to
      * the constructor.
+     * @param inputs defensively copied
      */
     void setInputs(final Map<String, String> inputs)
     {
@@ -256,6 +257,7 @@ public final class SignedResult
     /**
      * For reflection-based construction only. Business code must provide this value to
      * the constructor.
+     * @param outcomes defensively copied
      */
     void setOutcomes(final Map<String, Float> outcomes)
     {

--- a/srcalc/src/main/java/gov/va/med/srcalc/security/SecurityUtil.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/security/SecurityUtil.java
@@ -1,0 +1,30 @@
+package gov.va.med.srcalc.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Authentication- and authorization-related utility methods.
+ */
+public final class SecurityUtil
+{
+    private SecurityUtil()
+    {
+        // No construction.
+    }
+
+    /**
+     * Returns the currently-authenticated security principal (in other words, the current
+     * user).
+     * @throws IllegalStateException if there is no currently-authenticated principal
+     */
+    public static VistaUserDetails getCurrentPrincipal()
+    {
+        final Authentication authn = SecurityContextHolder.getContext().getAuthentication();
+        if (authn == null)
+        {
+            throw new IllegalStateException("No current security principal");
+        }
+        return (VistaUserDetails)authn.getPrincipal();
+    }
+}

--- a/srcalc/src/main/java/gov/va/med/srcalc/security/VistaLinkVistaDaoFactory.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/security/VistaLinkVistaDaoFactory.java
@@ -1,8 +1,5 @@
 package gov.va.med.srcalc.security;
 
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-
 import gov.va.med.srcalc.vista.*;
 import gov.va.med.srcalc.vista.vistalink.VistaLinkProcedureCaller;
 
@@ -17,23 +14,10 @@ public class VistaLinkVistaDaoFactory implements VistaDaoFactory
         return new RpcVistaPersonDao(new VistaLinkProcedureCaller(division));
     }
     
-    /**
-     * Returns the current security principal.
-     */
-    protected VistaUserDetails getCurrentPrincipal()
-    {
-        final Authentication authn = SecurityContextHolder.getContext().getAuthentication();
-        if (authn == null)
-        {
-            throw new IllegalStateException("No current security principal");
-        }
-        return (VistaUserDetails)authn.getPrincipal();
-    }
-    
     @Override
     public VistaPatientDao getVistaPatientDao()
     {
-        final VistaUserDetails principal = getCurrentPrincipal();
+        final VistaUserDetails principal = SecurityUtil.getCurrentPrincipal();
 
         return new RpcVistaPatientDao(
                 new VistaLinkProcedureCaller(principal.getDivision()),
@@ -43,7 +27,7 @@ public class VistaLinkVistaDaoFactory implements VistaDaoFactory
     @Override
     public VistaSurgeryDao getVistaSurgeryDao()
     {
-        final VistaUserDetails principal = getCurrentPrincipal();
+        final VistaUserDetails principal = SecurityUtil.getCurrentPrincipal();
         
         return new RpcVistaSurgeryDao(
                 new VistaLinkProcedureCaller(principal.getDivision()),

--- a/srcalc/src/main/java/gov/va/med/srcalc/security/VistaUserDetails.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/security/VistaUserDetails.java
@@ -26,7 +26,7 @@ public class VistaUserDetails implements UserDetails
      */
     public VistaUserDetails(final VistaPerson vistaPerson)
     {
-        fVistaPerson = vistaPerson;
+        fVistaPerson = Objects.requireNonNull(vistaPerson);
     }
 
     /**
@@ -41,12 +41,20 @@ public class VistaUserDetails implements UserDetails
     
     public String getDivision()
     {
-        return fVistaPerson.getDivision();
+        return fVistaPerson.getStationNumber();
     }
     
     public String getDuz()
     {
         return fVistaPerson.getDuz();
+    }
+    
+    /**
+     * Returns the VistaPerson whom this object represents.
+     */
+    public VistaPerson getVistaPerson()
+    {
+        return fVistaPerson;
     }
     
     /**

--- a/srcalc/src/main/java/gov/va/med/srcalc/service/CalculationService.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/service/CalculationService.java
@@ -3,6 +3,8 @@ package gov.va.med.srcalc.service;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.dao.DataAccessException;
+
 import gov.va.med.srcalc.domain.calculation.*;
 import gov.va.med.srcalc.domain.model.Specialty;
 import gov.va.med.srcalc.util.MissingValuesException;
@@ -48,11 +50,13 @@ public interface CalculationService
             throws MissingValuesException;
 
     /**
-     * Saves the given calculation result to VistA.
+     * Saves the given calculation result to VistA and the database.
      * @param result the result to save
      * @param electronicSignature the electronic signature code of the signing
      * user
      * @return one of the {@link VistaPatientDao.SaveNoteCode} return codes
+     * @throws DataAccessException if the result could not be saved to the database or
+     * VistA for some reason
      */
     public VistaPatientDao.SaveNoteCode signRiskCalculation(
             CalculationResult result, String electronicSignature);

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RemoteProcedure.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RemoteProcedure.java
@@ -11,6 +11,11 @@ public enum RemoteProcedure
     GET_USER("SR ASRC USER"),
     
     /**
+     * Returns Person Classes for the current user.
+     */
+    GET_USER_PERSON_CLASSES("SR ASRC PERSON CLASSES"),
+    
+    /**
      * Returns information about the given patient.
      */
     GET_PATIENT("SR ASRC PATIENT"),

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPersonDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPersonDao.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
 
 import gov.va.med.srcalc.domain.VistaPerson;
 
@@ -22,6 +22,36 @@ public class RpcVistaPersonDao implements VistaPersonDao
     {
         fProcedureCaller = procedureCaller;
     }
+    
+    /**
+     * Loads the user's single Provider Type, if present.
+     */
+    private Optional<String> loadProviderType(final String duz)
+    {
+        final List<String> personClassResults = fProcedureCaller.doRpc(
+                duz, RemoteProcedure.GET_USER_PERSON_CLASSES);
+        
+        if (!personClassResults.isEmpty())
+        {
+            // The RPC returns an array, but a user should only have one non-expired
+            // Person Class in VistA.
+            if (personClassResults.size() > 1)
+            {
+                LOGGER.warn(
+                        "VistA unexpectedly returned more than one person class for " +
+                        " {}@{}: {}. All but the first one will be discarded.",
+                        duz,
+                        fProcedureCaller.getDivision(),
+                        personClassResults);
+            }
+            
+            return Optional.of(personClassResults.get(0));
+        }
+        else
+        {
+            return Optional.absent();
+        }
+    }
 
     public VistaPerson loadVistaPerson(final String duz)
     {
@@ -29,8 +59,6 @@ public class RpcVistaPersonDao implements VistaPersonDao
         
         final List<String> userResults = fProcedureCaller.doRpc(
                 duz, RemoteProcedure.GET_USER);
-        final List<String> personClassResults = fProcedureCaller.doRpc(
-                duz, RemoteProcedure.GET_USER_PERSON_CLASSES);
         
         // Get the first index in the array. We don't care about the rest.
         final String userString = userResults.get(0);
@@ -38,9 +66,7 @@ public class RpcVistaPersonDao implements VistaPersonDao
                 fProcedureCaller.getDivision(),
                 duz,
                 userString,
-                // Transform from a List to a Set, but the RPC result doesn't need any
-                // more than that.
-                ImmutableSet.copyOf(personClassResults));
+                loadProviderType(duz));
         LOGGER.debug("Loaded {} from VistA.", person);
         return person;
     }

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPersonDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPersonDao.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+
 import gov.va.med.srcalc.domain.VistaPerson;
 
 /**
@@ -25,12 +27,20 @@ public class RpcVistaPersonDao implements VistaPersonDao
     {
         LOGGER.debug("Loading VistaPerson for duz {}.", duz);
         
-        final List<String> results = fProcedureCaller.doRpc(duz, RemoteProcedure.GET_USER);
+        final List<String> userResults = fProcedureCaller.doRpc(
+                duz, RemoteProcedure.GET_USER);
+        final List<String> personClassResults = fProcedureCaller.doRpc(
+                duz, RemoteProcedure.GET_USER_PERSON_CLASSES);
         
         // Get the first index in the array. We don't care about the rest.
-        final String userString = results.get(0);
+        final String userString = userResults.get(0);
         final VistaPerson person = new VistaPerson(
-                fProcedureCaller.getDivision(), duz, userString, "user class not pulled");
+                fProcedureCaller.getDivision(),
+                duz,
+                userString,
+                // Transform from a List to a Set, but the RPC result doesn't need any
+                // more than that.
+                ImmutableSet.copyOf(personClassResults));
         LOGGER.debug("Loaded {} from VistA.", person);
         return person;
     }

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDao.java
@@ -1,10 +1,9 @@
 package gov.va.med.srcalc.vista;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Map;
 
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 
 import gov.va.med.srcalc.domain.calculation.SignedResult;
@@ -16,8 +15,8 @@ import gov.va.med.srcalc.domain.calculation.SignedResult;
  */
 public class RpcVistaSurgeryDao implements VistaSurgeryDao
 {
-    private static final DateTimeFormatter VISTA_DATE_TIME_FORMAT = 
-            DateTimeFormat.forPattern("MM/dd/YYYY@HHmm");
+    private static final SimpleDateFormat VISTA_DATE_FORMAT =
+            new SimpleDateFormat("MM/dd/yyyy@HHmm");
 
     private final VistaProcedureCaller fProcedureCaller;
     private final String fDuz;
@@ -52,7 +51,7 @@ public class RpcVistaSurgeryDao implements VistaSurgeryDao
                 fDuz,
                 String.valueOf(result.getPatientDfn()),
                 cptString,
-                VISTA_DATE_TIME_FORMAT.print(result.getSignatureDateTime()),
+                VISTA_DATE_FORMAT.format(result.getSignatureTimestamp()),
                 outcomes);
         
         final VistaOperationResult rpcResult =

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/VistaSurgeryDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/VistaSurgeryDao.java
@@ -1,5 +1,7 @@
 package gov.va.med.srcalc.vista;
 
+import org.springframework.dao.DataAccessException;
+
 import gov.va.med.srcalc.domain.calculation.SignedResult;
 
 /**
@@ -11,5 +13,9 @@ import gov.va.med.srcalc.domain.calculation.SignedResult;
  */
 public interface VistaSurgeryDao
 {
+    /**
+     * Saves the given SignedResult to VistA surgery.
+     * @throws DataAccessException if communication with VistA fails
+     */
     public void saveCalculationResult(final SignedResult result);
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/controller/DisplayResultsController.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/controller/DisplayResultsController.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpSession;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -76,10 +76,12 @@ public class DisplayResultsController
             resultString = fCalculationService.signRiskCalculation(
                     lastResult, electronicSignature).getDescription();
         }
-        catch(final RecoverableDataAccessException e)
+        catch (final DataAccessException e)
         {
-            LOGGER.warn("There was a problem connecting to VistA", e);
-            resultString = "There was a problem connecting to VistA.";
+            final String msg =
+                    "There was a problem communicating to the database or VistA.";
+            LOGGER.warn(msg, e);
+            resultString = msg;
         }
         // The json could be expanded to return more information/fields
         final HashMap<String, String> jsonStatus = new HashMap<>();

--- a/srcalc/src/main/resources/srcalc-context.xml
+++ b/srcalc/src/main/resources/srcalc-context.xml
@@ -44,6 +44,7 @@
     <bean id="riskModelDao" class="gov.va.med.srcalc.db.RiskModelDao" />
     <bean id="procedureDao" class="gov.va.med.srcalc.db.ProcedureDao" />
     <bean id="ruleDao" class="gov.va.med.srcalc.db.RuleDao" />
+    <bean id="resultsDao" class="gov.va.med.srcalc.db.ResultsDao" />
     <!-- Automatically translate any exceptions from the DAOs to Spring's
          DataAccessException hierarchy. -->
     <bean class="org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor" />

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/VistaPersonTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/VistaPersonTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
 
 /**
  * Tests the {@link VistaPerson} class.
@@ -19,13 +19,13 @@ public class VistaPersonTest
         final String DIVISION = "500";
         final String DUZ = "1";
         final String NAME = "PROGRAMMER,ONE";
-        final ImmutableSet<String> PROVIDER_TYPES = ImmutableSet.of("Person Class");
-        final VistaPerson person = new VistaPerson(DIVISION, DUZ, NAME, PROVIDER_TYPES);
+        final Optional<String> PROVIDER_TYPE = Optional.of("Person Class");
+        final VistaPerson person = new VistaPerson(DIVISION, DUZ, NAME, PROVIDER_TYPE);
         
         assertEquals(DIVISION, person.getStationNumber());
         assertEquals(DUZ, person.getDuz());
         assertEquals(NAME, person.getDisplayName());
-        assertEquals(PROVIDER_TYPES, person.getProviderTypes());
+        assertEquals(PROVIDER_TYPE, person.getProviderType());
         // We don't specify the format of the string, but make sure it includes
         // the division, DUZ, and name.
         assertThat(

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/VistaPersonTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/VistaPersonTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Tests the {@link VistaPerson} class.
  */
@@ -17,12 +19,13 @@ public class VistaPersonTest
         final String DIVISION = "500";
         final String DUZ = "1";
         final String NAME = "PROGRAMMER,ONE";
-        final VistaPerson person = new VistaPerson(
-                DIVISION, DUZ, NAME, "not implemented");
+        final ImmutableSet<String> PROVIDER_TYPES = ImmutableSet.of("Person Class");
+        final VistaPerson person = new VistaPerson(DIVISION, DUZ, NAME, PROVIDER_TYPES);
         
-        assertEquals(DIVISION, person.getDivision());
+        assertEquals(DIVISION, person.getStationNumber());
         assertEquals(DUZ, person.getDuz());
         assertEquals(NAME, person.getDisplayName());
+        assertEquals(PROVIDER_TYPES, person.getProviderTypes());
         // We don't specify the format of the string, but make sure it includes
         // the division, DUZ, and name.
         assertThat(

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
@@ -82,7 +82,8 @@ public class CalculationResultTest
                 "668",
                 startTimestamp,
                 10,
-                ImmutableSet.of("Provider Type"));
+                // Test an empty provider type.
+                Optional.<String>absent());
         final CalculationResult result = new CalculationResult(
                 historical,
                 100,

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
@@ -1,12 +1,16 @@
 package gov.va.med.srcalc.domain.calculation;
 
 import static org.junit.Assert.*;
+
+import java.util.HashMap;
+
 import gov.va.med.srcalc.domain.model.BooleanVariable;
 import gov.va.med.srcalc.domain.model.SampleModels;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -28,9 +32,9 @@ public class CalculationResultTest
     public final void testNullSpecialty() throws Exception
     {
         new CalculationResult(
-                new DateTime(),
-                100,
                 null,
+                100,
+                DateTime.now(),
                 ImmutableSet.<Value>of(),
                 ImmutableMap.of("model1", 45.1f));
     }
@@ -38,52 +42,76 @@ public class CalculationResultTest
     @Test
     public final void testWithProcedure() throws Exception
     {
+        /* Setup */
         final CalculationResult result = SampleCalculations.thoracicResult();
+        
+        /* Verification */
         
         assertTrue(result.getProcedureValue().isPresent());
         assertEquals(3, result.getNonProcedureValues().size());
         assertEquals(result.buildNoteBody(), NOTE_BODY);
+
+        // Most of signed() is verified in the next test, just test the CPT here.
+        final SignedResult signedResult = result.signed();
+        final ProcedureValue procedureValue = result.getProcedureValue().get();
+        assertEquals(
+                procedureValue.getValue().getCptCode(), signedResult.getCptCode().get());
     }
     
+    /**
+     * Tests a {@link CalculationResult} with no ProcedureValue but with other variables
+     * in the Procedure group.
+     */
     @Test
-    public final void testNoProcedure() throws Exception
+    public final void testNoProcedureValue() throws Exception
     {
-        final ImmutableSet<Value> values = ImmutableSet.of(
-                new BooleanValue(SampleModels.dnrVariable(), false),
-                new NumericalValue(SampleModels.ageVariable(), 50.1f));
-        final CalculationResult result = new CalculationResult(
-                new DateTime(),
-                100,
-                SampleModels.thoracicSpecialty().getName(),
-                values,
-                ImmutableMap.of("model1", 0.3f));
-        
-        assertFalse(result.getProcedureValue().isPresent());
-        assertEquals(values, result.getNonProcedureValues());
-    }
-    
-    @Test
-    public final void testProcedureGroup() throws Exception
-    {
+        /* Setup */
+        final DateTime startTimestamp = DateTime.now().minusMinutes(3);
+        final BooleanVariable procVar1 = new BooleanVariable(
+                "Dummy Boolean", SampleModels.procedureVariableGroup(), "dummy");
+        final BooleanVariable procVar2 = new BooleanVariable(
+                "Dummy Boolean 2", SampleModels.procedureVariableGroup(), "dummy2");
         final ImmutableSet<Value> values = ImmutableSet.of(
                 new BooleanValue(SampleModels.dnrVariable(), false),
                 new NumericalValue(SampleModels.ageVariable(), 50.0f),
-                new BooleanValue(new BooleanVariable(
-                        "Dummy Boolean",
-                        SampleModels.procedureVariableGroup(),
-                        "dummy"), false),
-                new BooleanValue(new BooleanVariable(
-                        "Dummy Boolean 2",
-                        SampleModels.procedureVariableGroup(),
-                        "dummy2"), false));
-        final CalculationResult result = new CalculationResult(
-                new DateTime(),
-                100,
+                new BooleanValue(procVar1, false),
+                new BooleanValue(procVar2, false));
+
+        final HistoricalCalculation historical = new HistoricalCalculation(
                 "Dummy Specialty",
+                "668",
+                startTimestamp,
+                10,
+                ImmutableSet.of("Provider Type"));
+        final CalculationResult result = new CalculationResult(
+                historical,
+                100,
+                DateTime.now(),
                 values,
                 ImmutableMap.of("Dummy Model", 1.0f));
         
+        /* Verification */
+        
+        assertEquals(Optional.absent(), result.getProcedureValue());
         assertEquals(values, result.getNonProcedureValues());
-        assertEquals(result.buildNoteBody(), NOTE_BODY_PROCEDURE_GROUP);
+        assertEquals(NOTE_BODY_PROCEDURE_GROUP, result.buildNoteBody());
+
+        // Also verify signed().
+        final HashMap<String, String> expectedInputs = new HashMap<>();
+        for (final Value val : result.getValues())
+        {
+            expectedInputs.put(val.getVariable().getKey(), val.getValue().toString());
+        }
+        final DateTime expectedSignatureTimestamp = DateTime.now().withMillisOfSecond(0);
+        final SignedResult signedResult = result.signed();
+
+        assertEquals(Optional.<String>absent(), signedResult.getCptCode());
+        assertSame(historical, signedResult.getHistoricalCalculation());
+        assertEquals(expectedInputs, signedResult.getInputs());
+        assertEquals(result.getOutcomes(), signedResult.getOutcomes());
+        assertEquals(result.getPatientDfn(), signedResult.getPatientDfn());
+        assertEquals(
+                expectedSignatureTimestamp.toDate(),
+                signedResult.getSignatureTimestamp());
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
@@ -165,7 +165,7 @@ public class CalculationTest
         // Assuming that 0 seconds elapse from Calculation.forPatient() to calculate()
         // above.
         assertEquals(0, historical.getSecondsToFirstRun());
-        assertEquals(user.getProviderTypes(), historical.getProviderTypes());
+        assertEquals(user.getProviderType(), historical.getProviderType());
         assertSame(
                 "getHistoricalCalculation() should return the same instance",
                 historical, c.getHistoricalCalculation().get());

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
@@ -1,17 +1,22 @@
 package gov.va.med.srcalc.domain.calculation;
 
+import static gov.va.med.srcalc.test.util.TestHelpers.assertWithinDelta;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import gov.va.med.srcalc.ConfigurationException;
 import gov.va.med.srcalc.domain.Patient;
+import gov.va.med.srcalc.domain.VistaPerson;
 import gov.va.med.srcalc.domain.model.*;
 import gov.va.med.srcalc.util.MissingValuesException;
 
 import java.util.*;
 
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tests the {@link Calculation} class.
@@ -22,14 +27,14 @@ public class CalculationTest
     public final void testForPatient()
     {
         final Patient patient = SampleCalculations.dummyPatient(1);
-        final DateTime testStartDateTime = new DateTime();
+        final DateTime testStartDateTime = DateTime.now();
         final Calculation c = Calculation.forPatient(patient);
         
-        assertTrue("start date not in the past",
+        assertTrue("start date should be in the past",
                 // DateTime has millisecond precision, so the current time may
                 // still be the same. Use "less than or equal to".
-                c.getStartDateTime().compareTo(new DateTime()) <= 0);
-        assertTrue("start date not after test start",
+                c.getStartDateTime().compareTo(DateTime.now()) <= 0);
+        assertTrue("start date should be after test start",
                 c.getStartDateTime().compareTo(testStartDateTime) >= 0);
         assertEquals(patient, c.getPatient());
     }
@@ -136,10 +141,12 @@ public class CalculationTest
         s.getRiskModels().add(dummyModel2);
         final Calculation c = Calculation.forPatient(SampleCalculations.dummyPatient(1));
         c.setSpecialty(s);
+        final VistaPerson user = SampleCalculations.radiologistPerson();
         
         // Behavior verification
-        final CalculationResult result = c.calculate(values);
-        assertEquals(c.getStartDateTime(), result.getStartDateTime());
+        final CalculationResult result = c.calculate(values, user);
+        // The system millis jump in increments of ~10, so just make sure we're within 50.
+        assertWithinDelta(DateTime.now(), result.getResultTime(), new Duration(50));
         assertEquals(c.getPatient().getDfn(), result.getPatientDfn());
         assertEquals(s.getName(), result.getSpecialtyName());
         assertEquals(values, result.getValues());
@@ -147,20 +154,36 @@ public class CalculationTest
         expectedOutcomes.put("model1", 55.3f);
         expectedOutcomes.put("model2", 22.3f);
         assertEquals(expectedOutcomes, result.getOutcomes());
+        
+        // Also verify output of getHistoricalCalculation().
+        final HistoricalCalculation historical = c.getHistoricalCalculation().get();
+        assertEquals(s.getName(), historical.getSpecialtyName());
+        assertEquals(user.getStationNumber(), historical.getUserStation());
+        assertEquals(
+                c.getStartDateTime().withMillisOfSecond(0).toDate(),
+                historical.getStartTimestamp());
+        // Assuming that 0 seconds elapse from Calculation.forPatient() to calculate()
+        // above.
+        assertEquals(0, historical.getSecondsToFirstRun());
+        assertEquals(user.getProviderTypes(), historical.getProviderTypes());
+        assertSame(
+                "getHistoricalCalculation() should return the same instance",
+                historical, c.getHistoricalCalculation().get());
     }
 
     @Test(expected = MissingValuesException.class)
     public final void testCalculateIncompleteValues() throws Exception
     {
         final Specialty thoracicSpecialty = SampleModels.thoracicSpecialty();
+        final ImmutableList<Value> incompleteValues = ImmutableList.of(
+                new BooleanValue(SampleModels.dnrVariable(), true),
+                new NumericalValue(SampleModels.ageVariable(), 12));
         
         // Create the class under test.
         final Calculation calc = Calculation.forPatient(SampleCalculations.dummyPatient(1));
         calc.setSpecialty(thoracicSpecialty);
         
         // Behavior verification
-        calc.calculate(Arrays.asList(
-                new BooleanValue(SampleModels.dnrVariable(), true),
-                new NumericalValue(SampleModels.ageVariable(), 12)));
+        calc.calculate(incompleteValues, SampleCalculations.radiologistPerson());
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculationTest.java
@@ -1,8 +1,12 @@
 package gov.va.med.srcalc.domain.calculation;
 
+import gov.va.med.srcalc.test.util.TestHelpers;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
+
+import com.google.common.base.Optional;
 
 /**
  * Unit tests for {@link HistoricalCalculation}.
@@ -13,6 +17,15 @@ public class HistoricalCalculationTest
     public final void testEquals()
     {
         EqualsVerifier.forClass(HistoricalCalculation.class);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testProviderTypeTooLong()
+    {
+        new HistoricalCalculation(
+                "specialty", "512", DateTime.now(), 1, Optional.of(
+                        TestHelpers.stringOfLength(HistoricalCalculation.PROVIDER_TYPE_MAX + 1)));
+        
     }
     
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculationTest.java
@@ -1,0 +1,18 @@
+package gov.va.med.srcalc.domain.calculation;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link HistoricalCalculation}.
+ */
+public class HistoricalCalculationTest
+{
+    @Test
+    public final void testEquals()
+    {
+        EqualsVerifier.forClass(HistoricalCalculation.class);
+    }
+    
+}

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
@@ -1,19 +1,31 @@
 package gov.va.med.srcalc.domain.calculation;
 
 import gov.va.med.srcalc.domain.Patient;
+import gov.va.med.srcalc.domain.VistaPerson;
 import gov.va.med.srcalc.domain.model.*;
+import gov.va.med.srcalc.util.MissingValuesException;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Constructs sample instances of {@link Calculation}s and related objects.
  */
 public class SampleCalculations
 {
+    /**
+     * Returns a sample radiologist VistA user.
+     */
+    public static VistaPerson radiologistPerson()
+    {
+        return new VistaPerson("500", "11716",
+                "RADIOLOGIST,ONE",
+                ImmutableSet.of("Physicians (M.D. and D.O.)"));
+    }
 
     public static Patient dummyPatient(final int dfn)
     {
@@ -31,23 +43,52 @@ public class SampleCalculations
         patient.setLabs(labs);
         return patient;
     }
+
+    /**
+     * Returns a collection of value values for a thoracic calculation.
+     * @return a Map from each Variable to its Value
+     */
+    public static ImmutableMap<AbstractVariable, Value> thoracicValues()
+    {
+        final BooleanVariable dnrVar = SampleModels.dnrVariable();
+        final NumericalVariable ageVar = SampleModels.ageVariable();
+        final MultiSelectVariable fsVar = SampleModels.functionalStatusVariable();
+        final ProcedureVariable procVar = SampleModels.procedureVariable();
+        try
+        {
+            return ImmutableMap.of(
+                    dnrVar,
+                    new BooleanValue(dnrVar, false),
+                    ageVar,
+                    new NumericalValue(ageVar, 45.0f),
+                    fsVar,
+                    new MultiSelectValue(fsVar, new MultiSelectOption("Independent")),
+                    procVar,
+                    new ProcedureValue(procVar, SampleModels.repairLeftProcedure()));
+        }
+        catch (final InvalidValueException ex)
+        {
+            throw new RuntimeException("test data had an invalid value", ex);
+        }
+    }
     
     /**
      * Create a new calculation for a dummy patient, set the specialty,
      * and then perform the calculation using the a custom set of values.
-     * @return a {@link Calculation} object after the calculation is performed
-     * @throws Exception
+     * @return a realistic CalculationResult
      */
-    public static CalculationResult thoracicResult() throws Exception
+    public static CalculationResult thoracicResult()
     {
+
         final Calculation calc = Calculation.forPatient(dummyPatient(1));
         calc.setSpecialty(SampleModels.thoracicSpecialty());
-        final List<Value> values = new ArrayList<Value>();
-        values.add(new BooleanValue(SampleModels.dnrVariable(), false));
-        values.add(new NumericalValue(SampleModels.ageVariable(), 45.0f));
-        values.add(new MultiSelectValue(SampleModels.functionalStatusVariable(), new MultiSelectOption("Independent")));
-        values.add(new ProcedureValue(SampleModels.procedureVariable(), SampleModels.repairLeftProcedure()));
-        return calc.calculate(values);
+        try
+        {
+            return calc.calculate(thoracicValues().values(), radiologistPerson());
+        }
+        catch (final MissingValuesException ex)
+        {
+            throw new RuntimeException("test data did not provide all values", ex);
+        }
     }
-    
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
@@ -9,8 +9,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Constructs sample instances of {@link Calculation}s and related objects.
@@ -24,7 +24,7 @@ public class SampleCalculations
     {
         return new VistaPerson("500", "11716",
                 "RADIOLOGIST,ONE",
-                ImmutableSet.of("Physicians (M.D. and D.O.)"));
+                Optional.of("Physicians (M.D. and D.O.)"));
     }
 
     public static Patient dummyPatient(final int dfn)

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SampleCalculations.java
@@ -45,7 +45,7 @@ public class SampleCalculations
     }
 
     /**
-     * Returns a collection of value values for a thoracic calculation.
+     * Returns a collection of variable values for a thoracic calculation.
      * @return a Map from each Variable to its Value
      */
     public static ImmutableMap<AbstractVariable, Value> thoracicValues()

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SignedResultTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SignedResultTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Tests the {@link SignedResult} class.
@@ -25,7 +24,7 @@ public class SignedResultTest
     private HistoricalCalculation makeHistoricalCalc()
     {
         return new HistoricalCalculation(
-                "Dummy", "442", DateTime.now(), 123, ImmutableSet.of("Provider Type"));
+                "Dummy", "442", DateTime.now(), 123, Optional.of("Provider Type"));
     }
 
     @Test

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SignedResultTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/SignedResultTest.java
@@ -3,6 +3,7 @@ package gov.va.med.srcalc.domain.calculation;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
+import gov.va.med.srcalc.domain.model.SampleModels;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 import org.joda.time.DateTime;
@@ -10,16 +11,39 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Tests the {@link SignedResult} class.
  */
 public class SignedResultTest
 {
+    /**
+     * Constructs a {@link HistoricalCalculation} with dummy values. Useful when we need
+     * an instance but don't care what it contains.
+     */
+    private HistoricalCalculation makeHistoricalCalc()
+    {
+        return new HistoricalCalculation(
+                "Dummy", "442", DateTime.now(), 123, ImmutableSet.of("Provider Type"));
+    }
+
     @Test
     public final void testEquals()
     {
         EqualsVerifier.forClass(SignedResult.class).verify();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public final void testBadCptCode()
+    {
+        new SignedResult(
+                makeHistoricalCalc(),
+                500,
+                Optional.of("4444"),
+                DateTime.now(),
+                ImmutableMap.<String, String>of(),
+                ImmutableMap.<String, Float>of());
     }
     
     /**
@@ -29,20 +53,20 @@ public class SignedResultTest
     @Test
     public final void testToString()
     {
+        final HistoricalCalculation historical = makeHistoricalCalc();
         final int patientDfn = 100;
-        final String specialty = "Urology";
-        final String cptCode = "10005";
+        final String cptCode = SampleModels.repairLeftProcedure().getCptCode();
 
         final SignedResult result = new SignedResult(
+                historical,
                 patientDfn,
-                specialty,
                 Optional.of(cptCode),
-                new DateTime(),
-                new DateTime(),
+                DateTime.now(),
+                ImmutableMap.<String, String>of(),
                 ImmutableMap.<String, Float>of());
         
         assertThat(result.toString(), allOf(
-                containsString(specialty),
+                containsString(historical.toString()),
                 containsString(cptCode),
                 containsString(String.valueOf(patientDfn))));
     }

--- a/srcalc/src/test/java/gov/va/med/srcalc/security/SecurityUtilTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/security/SecurityUtilTest.java
@@ -1,0 +1,20 @@
+package gov.va.med.srcalc.security;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SecurityUtil}.
+ */
+public class SecurityUtilTest
+{
+    /**
+     * Tests that {@link SecurityUtil#getCurrentPrincipal()} throws an {@link
+     * IllegalStateException} if there is not current principal.
+     */
+    @Test(expected = IllegalStateException.class)
+    public final void testNoCurrentPrincipal()
+    {
+        SecurityUtil.getCurrentPrincipal();
+    }
+    
+}

--- a/srcalc/src/test/java/gov/va/med/srcalc/security/VistaUserDetailsServiceTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/security/VistaUserDetailsServiceTest.java
@@ -1,8 +1,8 @@
 package gov.va.med.srcalc.security;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import gov.va.med.srcalc.domain.VistaPerson;
+import gov.va.med.srcalc.domain.calculation.SampleCalculations;
 import gov.va.med.srcalc.vista.*;
 
 import org.junit.Test;
@@ -13,24 +13,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  */
 public class VistaUserDetailsServiceTest
 {
-    private static final String DIVISION = "500";
-    private static final String RADIOLOGIST_DUZ = "11716";
-    private static final String UNKNOWN_DUZ = "11111";
-    
-    protected VistaPerson sampleRadiologist()
-    {
-        final VistaPerson radiologist = new VistaPerson(
-                DIVISION, RADIOLOGIST_DUZ, "RADIOLOGIST,ONE", "unknown");
-        return radiologist;
-    }
-
-    protected VistaPersonDao mockVistaDao()
-    {
-        final VistaPersonDao dao = mock(VistaPersonDao.class);
-        when(dao.loadVistaPerson(RADIOLOGIST_DUZ)).thenReturn(sampleRadiologist());
-        when(dao.loadVistaPerson(UNKNOWN_DUZ)).thenThrow(new IllegalArgumentException());
-        return dao;
-    }
+    private final MockVistaPersonDao fVistaPersonDao = new MockVistaPersonDao();
     
     protected VistaDaoFactory mockVistaDaoFactory()
     {
@@ -39,7 +22,7 @@ public class VistaUserDetailsServiceTest
             @Override
             public VistaPersonDao getVistaPersonDao(String division)
             {
-                return mockVistaDao();
+                return fVistaPersonDao;
             }
             
             @Override
@@ -59,26 +42,30 @@ public class VistaUserDetailsServiceTest
     @Test
     public final void testLoadUserByUsername()
     {
-        final VistaPerson samplePerson = sampleRadiologist();
+        final VistaPerson samplePerson = SampleCalculations.radiologistPerson();
         
         final VistaUserDetailsService service = new VistaUserDetailsService(mockVistaDaoFactory());
         final VistaUserDetails user = service.loadUserByUsername(samplePerson.getDuz());
-        assertEquals(samplePerson.getDivision(), user.getDivision());
+        assertEquals(samplePerson.getStationNumber(), user.getDivision());
         assertEquals(samplePerson.getDuz(), user.getDuz());
         assertEquals(samplePerson.getDuz(), user.getUsername());
         assertEquals("", user.getPassword());
         assertEquals(samplePerson.getDisplayName(), user.getDisplayName());
-        assertTrue("user does not have ROLE_USER",
+        assertTrue("user should have ROLE_USER",
                 user.getAuthorities().contains(Roles.ROLE_USER.asGrantedAuthority()));
-        assertFalse("user has ROLE_ADMIN",
+        assertFalse("user should not have ROLE_ADMIN",
                 user.getAuthorities().contains(Roles.ROLE_ADMIN.asGrantedAuthority()));
+        assertTrue("user should be enabled", user.isEnabled());
+        assertTrue("user should be non-expired", user.isAccountNonExpired());
+        assertTrue("user should be non-locked", user.isAccountNonLocked());
+        assertTrue("user credentials should be non-expired", user.isCredentialsNonExpired());
     }
     
     @Test(expected = UsernameNotFoundException.class)
     public final void testLoadUnknownUser()
     {
         final VistaUserDetailsService service = new VistaUserDetailsService(mockVistaDaoFactory());
-        service.loadUserByUsername(UNKNOWN_DUZ);
+        service.loadUserByUsername("11111");
     }
     
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/service/CalculationServiceIT.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/service/CalculationServiceIT.java
@@ -7,11 +7,13 @@ import java.util.*;
 import gov.va.med.srcalc.domain.calculation.*;
 import gov.va.med.srcalc.domain.model.*;
 import gov.va.med.srcalc.test.util.IntegrationTest;
+import gov.va.med.srcalc.test.util.TestAuthnProvider;
 
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -35,6 +37,9 @@ public class CalculationServiceIT extends IntegrationTest
     @Inject // field-based autowiring only in tests
     CalculationService fCalculationService;
     
+    @Rule
+    public final TestAuthnProvider fAuthnProvider = new TestAuthnProvider();
+    
     @Test
     public void testGetValidSpecialties()
     {
@@ -48,17 +53,17 @@ public class CalculationServiceIT extends IntegrationTest
     {
         // Test setup and configuration
         final int PATIENT_DFN = 1;
-        final DateTime testStartDateTime = new DateTime();
+        final DateTime testStartDateTime = DateTime.now();
         
         // Behavior verification
         final Calculation calc = fCalculationService.startNewCalculation(
                 PATIENT_DFN);
         assertEquals(PATIENT_DFN, calc.getPatient().getDfn());
-        assertTrue("start date not in the past",
+        assertTrue("start date should be in the past",
                 // DateTime has millisecond precision, so the current time may
                 // still be the same. Use "less than or equal to".
-                calc.getStartDateTime().compareTo(new DateTime()) <= 0);
-        assertTrue("start date not after test start",
+                calc.getStartDateTime().compareTo(DateTime.now()) <= 0);
+        assertTrue("start date should be after test start",
                 calc.getStartDateTime().compareTo(testStartDateTime) >= 0);
     }
     

--- a/srcalc/src/test/java/gov/va/med/srcalc/service/CalculationServiceIT.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/service/CalculationServiceIT.java
@@ -156,7 +156,7 @@ public class CalculationServiceIT extends IntegrationTest
         final String procedureKey = "procedure";
         final String ageKey = "age";
 
-        // Create a Calculation just for easy access to the variabes.
+        // Create a Calculation just for easy access to the variables.
         final Calculation calc = fCalculationService.startNewCalculation(patientDfn);
         fCalculationService.setSpecialty(calc, "Neurosurgery");
         final Map<String, Variable> neuroVars = buildVariableMap(calc.getVariables());

--- a/srcalc/src/test/java/gov/va/med/srcalc/service/DefaultCalculationServiceTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/service/DefaultCalculationServiceTest.java
@@ -17,8 +17,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import sun.security.x509.FreshestCRLExtension;
-
 import com.google.common.collect.ImmutableMap;
 
 /**

--- a/srcalc/src/test/java/gov/va/med/srcalc/service/DefaultCalculationServiceTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/service/DefaultCalculationServiceTest.java
@@ -2,15 +2,24 @@ package gov.va.med.srcalc.service;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+
+import gov.va.med.srcalc.db.ResultsDao;
 import gov.va.med.srcalc.db.SpecialtyDao;
 import gov.va.med.srcalc.domain.calculation.*;
-import gov.va.med.srcalc.domain.model.SampleModels;
-import gov.va.med.srcalc.domain.model.Specialty;
+import gov.va.med.srcalc.domain.model.*;
+import gov.va.med.srcalc.test.util.TestAuthnProvider;
 import gov.va.med.srcalc.vista.*;
 
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
+import sun.security.x509.FreshestCRLExtension;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests the {@link DefaultCalculationService} class. Note that these are unit tests, not
@@ -23,8 +32,12 @@ public class DefaultCalculationServiceTest
     private static final String VALID_ESIG_CODE = "eSigCode";
     
     private SpecialtyDao fMockSpecialtyDao;
-    private VistaPatientDao fPatientDao;
-    private VistaSurgeryDao fSurgeryDao;
+    private VistaPatientDao fMockPatientDao;
+    private VistaSurgeryDao fMockSurgeryDao;
+    private ResultsDao fMockResultsDao;
+    
+    @Rule
+    public final TestAuthnProvider fAuthnProvider = new TestAuthnProvider();
     
     @Before
     public void setup()
@@ -36,25 +49,34 @@ public class DefaultCalculationServiceTest
         when(fMockSpecialtyDao.getByName(specialty.getName())).thenReturn(specialty);
         
         // And make VistaPatientDao.getPatient actually return a patient.
-        fPatientDao = mock(VistaPatientDao.class);
-        when(fPatientDao.getPatient(SAMPLE_PATIENT_DFN))
+        fMockPatientDao = mock(VistaPatientDao.class);
+        when(fMockPatientDao.getPatient(SAMPLE_PATIENT_DFN))
             .thenReturn(SampleCalculations.dummyPatient(SAMPLE_PATIENT_DFN));
         // Default to bad signature.
-        when(fPatientDao.saveRiskCalculationNote(anyInt(), anyString(), anyString()))
+        when(fMockPatientDao.saveRiskCalculationNote(anyInt(), anyString(), anyString()))
             .thenReturn(VistaPatientDao.SaveNoteCode.INVALID_SIGNATURE);
-        when(fPatientDao.saveRiskCalculationNote(eq(SAMPLE_PATIENT_DFN), eq(VALID_ESIG_CODE), anyString()))
+        when(fMockPatientDao.saveRiskCalculationNote(eq(SAMPLE_PATIENT_DFN), eq(VALID_ESIG_CODE), anyString()))
             .thenReturn(VistaPatientDao.SaveNoteCode.SUCCESS);
 
         // These don't need any special setup: we just verify certain calls.
-        fSurgeryDao = MockVistaDaos.mockSurgeryDao();
+        fMockSurgeryDao = MockVistaDaos.mockSurgeryDao();
+        fMockResultsDao = mock(ResultsDao.class);
+    }
+    
+    /**
+     * Constructs a new DefaultCalculationService using the above mock DAOs.
+     */
+    private DefaultCalculationService createWithMocks()
+    {
+        return new DefaultCalculationService(
+                fMockSpecialtyDao, fMockPatientDao, fMockSurgeryDao, fMockResultsDao);
     }
     
     @Test
     public final void testGetValidSpecialties()
     {
         // Create the class under test.
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
 
         // Behavior verification.
         assertEquals(SampleModels.specialtyList(), s.getValidSpecialties());
@@ -63,20 +85,19 @@ public class DefaultCalculationServiceTest
     @Test
     public final void testStartNewCalculation()
     {
-        final DateTime testStartDateTime = new DateTime();
+        final DateTime testStartDateTime = DateTime.now();
 
         // Create the class under test.
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
         
         // Behavior verification.
         final Calculation calc = s.startNewCalculation(SAMPLE_PATIENT_DFN);
         assertEquals(SAMPLE_PATIENT_DFN, calc.getPatient().getDfn());
-        assertTrue("start date not in the past",
+        assertTrue("start date should be in the past",
                 // DateTime has millisecond precision, so the current time may
                 // still be the same. Use "less than or equal to".
-                calc.getStartDateTime().compareTo(new DateTime()) <= 0);
-        assertTrue("start date not after test start",
+                calc.getStartDateTime().compareTo(DateTime.now()) <= 0);
+        assertTrue("start date should be after test start",
                 calc.getStartDateTime().compareTo(testStartDateTime) >= 0);
     }
     
@@ -86,8 +107,7 @@ public class DefaultCalculationServiceTest
         final Specialty thoracicSpecialty = SampleModels.thoracicSpecialty();
         
         // Create the class under test.
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
         final Calculation calc = s.startNewCalculation(SAMPLE_PATIENT_DFN);
         
         // Behavior verification.
@@ -101,8 +121,7 @@ public class DefaultCalculationServiceTest
         final int PATIENT_DFN = 1;
         
         // Create the class under test.
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
         final Calculation calc = s.startNewCalculation(PATIENT_DFN);
         
         // Behavior verification.
@@ -110,10 +129,39 @@ public class DefaultCalculationServiceTest
     }
     
     @Test
+    public final void testRunCalculation() throws Exception
+    {
+        // Setup
+        final Specialty thoracicSpecialty = SampleModels.thoracicSpecialty();
+        final DefaultCalculationService s = createWithMocks();
+        final Calculation calc = s.startNewCalculation(SAMPLE_PATIENT_DFN);
+        s.setSpecialty(calc, thoracicSpecialty.getName());
+        final ImmutableMap<AbstractVariable, Value> thoracicValues =
+                SampleCalculations.thoracicValues();
+        
+        /* Behavior & Verification */
+        
+        s.runCalculation(calc, thoracicValues.values());
+        // First run: for ASRC-59, we will have to persist the HistoricalCalculation here,
+        // but for now we don't.
+        verify(fMockResultsDao, never())
+            .persistHistoricalCalc(calc.getHistoricalCalculation().get());
+        
+        // Try now with tweaked values and verify that the service didn't try to
+        // re-persist the HistoricalCalculation.
+        final HashMap<AbstractVariable, Value> tweakedValues =
+                new HashMap<>(thoracicValues);
+        final ProcedureVariable procVar = SampleModels.procedureVariable();
+        tweakedValues.put(procVar, procVar.makeValue(SampleModels.repairRightProcedure()));
+        s.runCalculation(calc, tweakedValues.values());
+        verify(fMockResultsDao, never())
+            .persistHistoricalCalc(calc.getHistoricalCalculation().get());
+    }
+    
+    @Test
     public final void testSignCalculation() throws Exception
     {
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
         final CalculationResult result = SampleCalculations.thoracicResult();
         final SignedResult expectedSignedResult = result.signed();
 
@@ -121,28 +169,29 @@ public class DefaultCalculationServiceTest
         s.signRiskCalculation(result, VALID_ESIG_CODE);
         
         // Verification
-        verify(fPatientDao).saveRiskCalculationNote(
+        verify(fMockPatientDao).saveRiskCalculationNote(
                 result.getPatientDfn(), VALID_ESIG_CODE, result.buildNoteBody());
-        // SignedResult.equals() compares the times at second precision, so
-        // this test will fail if the second happens to roll over during this
-        // test. The chance of this happening should be <1%.
-        verify(fSurgeryDao).saveCalculationResult(expectedSignedResult);
+        // SignedResult.equals() compares the times at second precision, so this test will
+        // fail if the second happens to roll over during this test. The chance of this
+        // happening should be <1%.
+        verify(fMockSurgeryDao).saveCalculationResult(expectedSignedResult);
+        verify(fMockResultsDao).persistSignedResult(expectedSignedResult);
     }
     
     @Test
     public final void testSignCalculationInvalidSig() throws Exception
     {
         final String invalidSigCode = "invalidCode";
-        final DefaultCalculationService s = new DefaultCalculationService(
-                fMockSpecialtyDao, fPatientDao, fSurgeryDao);
+        final DefaultCalculationService s = createWithMocks();
         final CalculationResult result = SampleCalculations.thoracicResult();
 
         // Behavior
         s.signRiskCalculation(result, invalidSigCode);
         
         // Verification
-        verify(fPatientDao).saveRiskCalculationNote(
+        verify(fMockPatientDao).saveRiskCalculationNote(
                 result.getPatientDfn(), invalidSigCode, result.buildNoteBody());
-        verify(fSurgeryDao, never()).saveCalculationResult(any(SignedResult.class));
+        verify(fMockSurgeryDao, never()).saveCalculationResult((SignedResult)anyObject());
+        verify(fMockResultsDao, never()).persistSignedResult((SignedResult)anyObject());
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/test/util/IntegrationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/test/util/IntegrationTest.java
@@ -35,6 +35,24 @@ public abstract class IntegrationTest
         return fSessionFactory.getCurrentSession();
     }
     
+    /**
+     * <p>Simluates a new Hibernate Session by flushing and clearing the current Session.
+     * </p>
+     * 
+     * <p>Many integration tests span multiple user requests, which would normally be
+     * executed under separate transactions and therefore separate Hibernate Sessions.
+     * These tests, however, run in a single transaction and therefore a single Session,
+     * so this method is useful to simulate a new Session to make the tests a bit more
+     * realistic.</p>
+     */
+    protected void simulateNewSession()
+    {
+        fLogger.info(
+                "Flushing and clearing the Hibernate Session to simulate a new one.");
+        getHibernateSession().flush();
+        getHibernateSession().clear();
+    }
+    
     @After
     public void after()
     {

--- a/srcalc/src/test/java/gov/va/med/srcalc/test/util/TestAuthnProvider.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/test/util/TestAuthnProvider.java
@@ -1,0 +1,38 @@
+package gov.va.med.srcalc.test.util;
+
+import gov.va.med.srcalc.domain.calculation.SampleCalculations;
+import gov.va.med.srcalc.security.VistaUserDetails;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * JUnit rule that sets the current authenticated principal to {@link
+ * SampleCalculations#radiologistPerson()} for each test and clears it afterwards.
+ */
+public class TestAuthnProvider extends TestWatcher
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestAuthnProvider.class);
+    
+    @Override
+    protected void starting(final Description description)
+    {
+        LOGGER.debug("Setting mock authentication for test {}.", description);
+        final Authentication authn = new UsernamePasswordAuthenticationToken(
+                new VistaUserDetails(SampleCalculations.radiologistPerson()),
+                null);
+        SecurityContextHolder.getContext().setAuthentication(authn);
+    }
+    
+    @Override
+    protected void finished(final Description description)
+    {
+        LOGGER.debug("Clearing mock authentication for test {}.", description);
+        SecurityContextHolder.getContext().setAuthentication(null);
+    }
+}

--- a/srcalc/src/test/java/gov/va/med/srcalc/test/util/TestHelpers.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/test/util/TestHelpers.java
@@ -1,9 +1,12 @@
 package gov.va.med.srcalc.test.util;
 
 import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 import java.util.*;
 
+import org.joda.time.ReadableDuration;
+import org.joda.time.ReadableInstant;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
@@ -113,5 +116,18 @@ public class TestHelpers
         assertEquals(
                 ImmutableSet.copyOf(expectedErrors),
                 toSimpleErrors(errorsObject.getFieldErrors()));
+    }
+    
+    /**
+     * Asserts that the actual instant is within a certain delta of an expected instant.
+     */
+    public static void assertWithinDelta(
+            final ReadableInstant expected,
+            final ReadableInstant actual,
+            final ReadableDuration permittedDelta)
+    {
+        assertThat(
+                Math.abs(expected.getMillis() - actual.getMillis()),
+                lessThanOrEqualTo(permittedDelta.getMillis()));
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/MockVistaPersonDao.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/MockVistaPersonDao.java
@@ -1,0 +1,29 @@
+package gov.va.med.srcalc.vista;
+
+import gov.va.med.srcalc.domain.VistaPerson;
+import gov.va.med.srcalc.domain.calculation.SampleCalculations;
+
+/**
+ * A mock implementation of {@link VistaPersonDao} that returns sample data.
+ */
+public class MockVistaPersonDao implements VistaPersonDao
+{
+    /**
+     * Returns {@link SampleCalculations#radiologistPerson()} if the DUZ matches.
+     * Otherwise, throws {@link IllegalArgumentException}.
+     */
+    @Override
+    public VistaPerson loadVistaPerson(final String duz)
+    {
+        final VistaPerson radiologist = SampleCalculations.radiologistPerson();
+        if (duz.equals(radiologist.getDuz()))
+        {
+            return radiologist;
+        }
+        else
+        {
+            throw new IllegalArgumentException("mock DAO doesn't know that DUZ");
+        }
+    }
+    
+}

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPersonDaoTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPersonDaoTest.java
@@ -10,7 +10,8 @@ import gov.va.med.srcalc.domain.VistaPerson;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tests the {@link RpcVistaPersonDao} class.
@@ -20,10 +21,8 @@ public class RpcVistaPersonDaoTest
     private final static String DIVISION = "512";
     private final static String RADIOLOGIST_DUZ = "11716";
     private final static String RADIOLOGIST_NAME = "RADIOLOGIST,ONE";
-    private final static ImmutableSet<String> RADIOLOGIST_PROVIDER_TYPES =
-            ImmutableSet.of(
-                    "Physicians (M.D. and D.O.)",
-                    "Podiatric Medicine and Surgery Service Providers");
+    private final static String RADIOLOGIST_PROVIDER_TYPE =
+                    "Podiatric Medicine and Surgery Service Providers";
     
     private VistaProcedureCaller mockProcedureCaller()
     {
@@ -31,8 +30,9 @@ public class RpcVistaPersonDaoTest
         when(caller.getDivision()).thenReturn(DIVISION);
         when(caller.doRpc(RADIOLOGIST_DUZ, RemoteProcedure.GET_USER))
             .thenReturn(Arrays.asList(RADIOLOGIST_NAME));
+        // Test returning an extra type.
         when(caller.doRpc(RADIOLOGIST_DUZ, RemoteProcedure.GET_USER_PERSON_CLASSES))
-            .thenReturn(RADIOLOGIST_PROVIDER_TYPES.asList());
+            .thenReturn(ImmutableList.of(RADIOLOGIST_PROVIDER_TYPE, "Extra Type"));
         return caller;
     }
 
@@ -47,7 +47,7 @@ public class RpcVistaPersonDaoTest
         assertEquals(RADIOLOGIST_DUZ, person.getDuz());
         assertEquals(RADIOLOGIST_NAME, person.getDisplayName());
         assertEquals(DIVISION, person.getStationNumber());
-        assertEquals(RADIOLOGIST_PROVIDER_TYPES, person.getProviderTypes());
+        assertEquals(Optional.of(RADIOLOGIST_PROVIDER_TYPE), person.getProviderType());
     }
     
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPersonDaoTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPersonDaoTest.java
@@ -10,30 +10,44 @@ import gov.va.med.srcalc.domain.VistaPerson;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Tests the {@link RpcVistaPersonDao} class.
  */
 public class RpcVistaPersonDaoTest
 {
+    private final static String DIVISION = "512";
     private final static String RADIOLOGIST_DUZ = "11716";
     private final static String RADIOLOGIST_NAME = "RADIOLOGIST,ONE";
+    private final static ImmutableSet<String> RADIOLOGIST_PROVIDER_TYPES =
+            ImmutableSet.of(
+                    "Physicians (M.D. and D.O.)",
+                    "Podiatric Medicine and Surgery Service Providers");
+    
+    private VistaProcedureCaller mockProcedureCaller()
+    {
+        final VistaProcedureCaller caller = mock(VistaProcedureCaller.class);
+        when(caller.getDivision()).thenReturn(DIVISION);
+        when(caller.doRpc(RADIOLOGIST_DUZ, RemoteProcedure.GET_USER))
+            .thenReturn(Arrays.asList(RADIOLOGIST_NAME));
+        when(caller.doRpc(RADIOLOGIST_DUZ, RemoteProcedure.GET_USER_PERSON_CLASSES))
+            .thenReturn(RADIOLOGIST_PROVIDER_TYPES.asList());
+        return caller;
+    }
 
     @Test
     public final void testLoadVistaPersonValid()
     {
         // Setup
-        final String division = "500";
-        final VistaProcedureCaller caller = mock(VistaProcedureCaller.class);
-        when(caller.getDivision()).thenReturn(division);
-        when(caller.doRpc(RADIOLOGIST_DUZ, RemoteProcedure.GET_USER))
-            .thenReturn(Arrays.asList(RADIOLOGIST_NAME));
-        final RpcVistaPersonDao dao = new RpcVistaPersonDao(caller);
+        final RpcVistaPersonDao dao = new RpcVistaPersonDao(mockProcedureCaller());
 
         // Behavior verification
         final VistaPerson person = dao.loadVistaPerson(RADIOLOGIST_DUZ);
         assertEquals(RADIOLOGIST_DUZ, person.getDuz());
         assertEquals(RADIOLOGIST_NAME, person.getDisplayName());
-        assertEquals(division, person.getDivision());
+        assertEquals(DIVISION, person.getStationNumber());
+        assertEquals(RADIOLOGIST_PROVIDER_TYPES, person.getProviderTypes());
     }
     
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDaoTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDaoTest.java
@@ -41,7 +41,7 @@ public class RpcVistaSurgeryDaoTest
                 "442",
                 startDateTime,
                 3,
-                ImmutableSet.<String>of());
+                Optional.<String>absent());
         return new SignedResult(
                 historicalCalc,
                 patientDfn,


### PR DESCRIPTION
Calculation metadata is captured in the HistoricalCalculation class and the actual results
in the SignedResult class. Both are persisted upon signature. For ASRC-59, we will have to
persist HistoricalCalculation immediately after the first run, but I encountered a
Hibernate issue when trying to do that here so that will have to wait.