### PR TITLE
ASRC-61: replace j.u.Date with joda's DateTime

### DIFF
--- a/srcalc/build.gradle
+++ b/srcalc/build.gradle
@@ -23,6 +23,7 @@ repositories {
 def springVersion = '4.0.7.RELEASE'
 def springSecurityVersion = '3.2.5.RELEASE'
 def slf4jVersion = '1.7.10'
+def hibernateVersion = '4.2.13.Final'
 
 configurations {
     // Don't ever depend on commons-logging, we use jcl-over-sl4j instead.
@@ -33,6 +34,14 @@ configurations {
     // resolution from automatically choosing the right version. Manually
     // exclude the old 2.x versions.
     all*.exclude group: 'javax.servlet', module: 'servlet-api'
+    
+    all {
+        resolutionStrategy {
+            // jadira usertype.core includes this dependency, which bumps the Hibernate
+            // version.
+            force group: 'org.hibernate', name: 'hibernate-entitymanager', version: hibernateVersion
+        }
+    }
     
     // We use the log4j binding in the tests, so exclude the JUL binding.
     testRuntime.exclude module: 'slf4j-jdk14'
@@ -67,14 +76,14 @@ dependencies {
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: slf4jVersion
-    compile 'org.hibernate:hibernate-core:4.2.13.Final'
+    compile group: 'org.hibernate', name: 'hibernate-core', version: hibernateVersion
 	compile group: 'org.springframework', name: 'spring-core', version: springVersion
 	compile group: 'org.springframework', name: 'spring-context', version: springVersion
 	compile group: 'org.springframework', name: 'spring-webmvc', version: springVersion
 	compile group: 'org.springframework', name: 'spring-orm', version: springVersion
 	compile group: 'org.springframework.security', name: 'spring-security-web', version: springSecurityVersion
 	compile group: 'org.springframework.security', name: 'spring-security-taglibs', version: springSecurityVersion
-	compile 'joda-time:joda-time:2.3'
+	compile 'joda-time:joda-time:2.7'
 	compile 'org.apache.commons:commons-lang3:3.3.2'
 	compile 'com.google.guava:guava:18.0'
 	compile 'org.apache.commons:commons-csv:1.1'
@@ -84,6 +93,7 @@ dependencies {
     // Spring-Security XML namespace
 	runtime group: 'org.springframework.security', name: 'spring-security-config', version: springSecurityVersion
 	runtime 'com.fasterxml.jackson.core:jackson-databind:2.3.5' 
+	runtime group: 'org.jadira.usertype', name: 'usertype.core', version: '4.0.0.GA'
     
     /* Test dependencies */
 

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/HistoricalCalculation.java
@@ -5,12 +5,12 @@ import gov.va.med.srcalc.domain.model.Specialty;
 import gov.va.med.srcalc.util.Preconditions;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.Objects;
 
 import javax.persistence.*;
 
 import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
 import org.joda.time.DateTime;
 
 import com.google.common.base.MoreObjects;
@@ -50,7 +50,7 @@ public final class HistoricalCalculation implements Serializable
     private int fId;
     private String fSpecialtyName;
     private String fUserStation;
-    private Date fStartTimestamp;
+    private DateTime fStartTimestamp;
     private int fSecondsToFirstRun;
     private Optional<String> fProviderType;
     
@@ -80,7 +80,7 @@ public final class HistoricalCalculation implements Serializable
         setSpecialtyName(specialtyName);
         fUserStation = providerStation;
         // See getStartTimetsamp() for why we enforce 0 millis of second.
-        fStartTimestamp = startTimestamp.withMillisOfSecond(0).toDate();
+        fStartTimestamp = startTimestamp.withMillisOfSecond(0);
         fSecondsToFirstRun = secondsToFirstRun;
         setProviderType(providerType);
     }
@@ -151,7 +151,8 @@ public final class HistoricalCalculation implements Serializable
      */
     @Basic
     @Column(nullable = false)
-    public Date getStartTimestamp()
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    public DateTime getStartTimestamp()
     {
         return fStartTimestamp;
     }
@@ -160,7 +161,7 @@ public final class HistoricalCalculation implements Serializable
      * For reflection-based construction only. Business code must provide this value to
      * the constructor.
      */
-    void setStartTimestamp(final Date dateTime)
+    void setStartTimestamp(final DateTime dateTime)
     {
         fStartTimestamp = Objects.requireNonNull(dateTime);
     }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/calculation/SignedResult.java
@@ -5,13 +5,13 @@ import gov.va.med.srcalc.domain.model.Variable;
 import gov.va.med.srcalc.util.DisplayNameConditions;
 import gov.va.med.srcalc.util.Preconditions;
 
-import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
 import javax.persistence.*;
 
 import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
 import org.joda.time.DateTime;
 
 import com.google.common.base.MoreObjects;
@@ -35,7 +35,7 @@ public final class SignedResult
     private HistoricalCalculation fHistoricalCalculation;
     private int fPatientDfn;
     private Optional<String> fCptCode;
-    private Date fSignatureTimestamp;
+    private DateTime fSignatureTimestamp;
     private ImmutableMap<String, String> fInputs;
     private ImmutableMap<String, Float> fOutcomes;
     
@@ -72,7 +72,7 @@ public final class SignedResult
         setPatientDfn(patientDfn);
         setCptCode(cptCode);
         // See getSignatureTimestamp() for why we enforce 0 millis of second.
-        setSignatureTimestamp(signatureTimestamp.withMillisOfSecond(0).toDate());
+        setSignatureTimestamp(signatureTimestamp.withMillisOfSecond(0));
         setInputs(inputs);
         setOutcomes(outcomes);
     }
@@ -188,7 +188,8 @@ public final class SignedResult
      */
     @Basic
     @Column(nullable = false)
-    public Date getSignatureTimestamp()
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    public DateTime getSignatureTimestamp()
     {
         return fSignatureTimestamp;
     }
@@ -197,7 +198,7 @@ public final class SignedResult
      * For reflection-based construction only. Business code must provide this value to
      * the constructor.
      */
-    void setSignatureTimestamp(final Date signatureTimestamp)
+    void setSignatureTimestamp(final DateTime signatureTimestamp)
     {
         fSignatureTimestamp = Objects.requireNonNull(signatureTimestamp);
     }

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaSurgeryDao.java
@@ -1,9 +1,10 @@
 package gov.va.med.srcalc.vista;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 
 import gov.va.med.srcalc.domain.calculation.SignedResult;
@@ -15,8 +16,8 @@ import gov.va.med.srcalc.domain.calculation.SignedResult;
  */
 public class RpcVistaSurgeryDao implements VistaSurgeryDao
 {
-    private static final SimpleDateFormat VISTA_DATE_FORMAT =
-            new SimpleDateFormat("MM/dd/yyyy@HHmm");
+    private static final DateTimeFormatter VISTA_DATE_TIME_FORMAT = 
+            DateTimeFormat.forPattern("MM/dd/YYYY@HHmm");
 
     private final VistaProcedureCaller fProcedureCaller;
     private final String fDuz;
@@ -51,7 +52,7 @@ public class RpcVistaSurgeryDao implements VistaSurgeryDao
                 fDuz,
                 String.valueOf(result.getPatientDfn()),
                 cptString,
-                VISTA_DATE_FORMAT.format(result.getSignatureTimestamp()),
+                VISTA_DATE_TIME_FORMAT.print(result.getSignatureTimestamp()),
                 outcomes);
         
         final VistaOperationResult rpcResult =

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationResultTest.java
@@ -112,7 +112,7 @@ public class CalculationResultTest
         assertEquals(result.getOutcomes(), signedResult.getOutcomes());
         assertEquals(result.getPatientDfn(), signedResult.getPatientDfn());
         assertEquals(
-                expectedSignatureTimestamp.toDate(),
+                expectedSignatureTimestamp,
                 signedResult.getSignatureTimestamp());
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/CalculationTest.java
@@ -160,7 +160,7 @@ public class CalculationTest
         assertEquals(s.getName(), historical.getSpecialtyName());
         assertEquals(user.getStationNumber(), historical.getUserStation());
         assertEquals(
-                c.getStartDateTime().withMillisOfSecond(0).toDate(),
+                c.getStartDateTime().withMillisOfSecond(0),
                 historical.getStartTimestamp());
         // Assuming that 0 seconds elapse from Calculation.forPatient() to calculate()
         // above.


### PR DESCRIPTION
We were previously using java.util.Date in HistoricalCalculation and SignedResult since
Hibernate supports these types out-of-the-box. This change, however, converts to joda's
DateTime, using Jadira Usertypes for Hibernate integration.