### PR TITLE
ASRC-31: Display Active Medications.

### DIFF
--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/Patient.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/Patient.java
@@ -30,6 +30,7 @@ public class Patient implements Serializable
     private RetrievedValue fHeight;
     private List<HealthFactor> fHealthFactors;
     private Map<String, RetrievedValue> fLabs;
+    private List<String> fActiveMedications;
     
     public Patient()
     {
@@ -43,6 +44,7 @@ public class Patient implements Serializable
         this.fAge = age;
         this.fLabs = new HashMap<String, RetrievedValue>();
         this.fHealthFactors = new ArrayList<HealthFactor>();
+        this.fActiveMedications = new ArrayList<String>();
     }
     
     /**
@@ -165,12 +167,20 @@ public class Patient implements Serializable
     }
     
     /**
-     * Returns the patient's health factors in the form of:
-     * "MM/dd/yy <health factor name>".
+     * Returns the patient's health factors as a list of {@link HealthFactor}s.
      */
     public List<HealthFactor> getHealthFactors()
     {
         return fHealthFactors;
+    }
+    
+    /**
+     * Returns the patient's medications as a list of Strings. Currently the only information
+     * needed is the name of each active medication.
+     */
+    public List<String> getActiveMedications()
+    {
+        return fActiveMedications;
     }
     
     @Override

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/Patient.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/Patient.java
@@ -176,7 +176,8 @@ public class Patient implements Serializable
     
     /**
      * Returns the patient's medications as a list of Strings. Currently the only information
-     * needed is the name of each active medication.
+     * needed is the name of each active medication. Although the date is not present, the
+     * medications are listed in order of most recent to least recent.
      */
     public List<String> getActiveMedications()
     {

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/VariableGroup.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/VariableGroup.java
@@ -18,6 +18,8 @@ public final class VariableGroup implements Comparable<VariableGroup>
      * be changed in the administrator UI.
      */
     public static final String PROCEDURE_GROUP = "Planned Procedure";
+    public static final String CLINICAL_GROUP = "Clinical Conditions or Diseases - Recent";
+    public static final String MEDICATIONS_GROUP = "Medications";
     
     private int fId;
     private String fName;

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RemoteProcedure.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RemoteProcedure.java
@@ -48,7 +48,12 @@ public enum RemoteProcedure
     /**
      * Returns any of the patient's health factors in the last year.
      */
-    GET_HEALTH_FACTORS("SR ASRC HEALTH FACTORS");
+    GET_HEALTH_FACTORS("SR ASRC HEALTH FACTORS"),
+    
+    /**
+     * Returns all VA and non-VA active medications for the patient.
+     */
+    GET_ACTIVE_MEDICATIONS("ORQQPS LIST");
 
     /**
      * VistA returns this string if {@link #SAVE_PROGRESS_NOTE} succeeds.

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPatientDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPatientDao.java
@@ -125,6 +125,7 @@ public class RpcVistaPatientDao implements VistaPatientDao
             // Retrieve all health factors in the last year from VistA and filter
             // by the list given to us by the NSO.
             retrieveHealthFactors(dfn, patient);
+            retrieveActiveMedications(dfn, patient);
             
             LOGGER.debug("Loaded {} from VistA.", patient);
             return patient;
@@ -269,6 +270,27 @@ public class RpcVistaPatientDao implements VistaPatientDao
         catch(final Exception e)
         {
             LOGGER.warn("Unable to retrieve health factors. {}", e.toString());
+        }
+    }
+    
+    private void retrieveActiveMedications(final int dfn, final Patient patient)
+    {
+        try
+        {
+            patient.getActiveMedications().clear();
+            // Leave the start and end dates blank so that we get only the current medications.
+            final List<String> rpcResults = fProcedureCaller.doRpc(
+                    fDuz, RemoteProcedure.GET_ACTIVE_MEDICATIONS, String.valueOf(dfn), "", "");
+            for(final String medResult: rpcResults)
+            {
+                final List<String> medInfo = Splitter.on('^').splitToList(medResult);
+                patient.getActiveMedications().add(medInfo.get(1));
+            }
+            LOGGER.debug("Retrieved Active Medications: {} ", patient.getActiveMedications());
+        }
+        catch(final Exception e)
+        {
+            LOGGER.warn("Unable to retrieve active medications. {}", e.toString());
         }
     }
     

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPatientDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/RpcVistaPatientDao.java
@@ -269,7 +269,7 @@ public class RpcVistaPatientDao implements VistaPatientDao
         }
         catch(final Exception e)
         {
-            LOGGER.warn("Unable to retrieve health factors. {}", e.toString());
+            LOGGER.warn("Unable to retrieve health factors. {}", e);
         }
     }
     
@@ -283,6 +283,8 @@ public class RpcVistaPatientDao implements VistaPatientDao
                     fDuz, RemoteProcedure.GET_ACTIVE_MEDICATIONS, String.valueOf(dfn), "", "");
             for(final String medResult: rpcResults)
             {
+                // The expected format is "<identifier>^<medication name>^<date>^^^<dose per day>"
+                // for example, "403962R;O^METOPROLOL TARTRATE 50MG TAB^3110228^^^3"
                 final List<String> medInfo = Splitter.on('^').splitToList(medResult);
                 patient.getActiveMedications().add(medInfo.get(1));
             }
@@ -290,7 +292,7 @@ public class RpcVistaPatientDao implements VistaPatientDao
         }
         catch(final Exception e)
         {
-            LOGGER.warn("Unable to retrieve active medications. {}", e.toString());
+            LOGGER.warn("Unable to retrieve active medications. {}", e);
         }
     }
     

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
@@ -216,7 +216,7 @@ public class EnterVariablesController
             groupList.add(new PopulatedDisplayGroup(varList, calculation.getPatient()));
         }
         
-        ReferenceInfoAdder.addRefInfo(map, groupList, calculation.getPatient());
+        ReferenceInfoAdder.addRefInfo(groupList, calculation.getPatient());
         // Finally, sort the List.
         Collections.sort(groupList);
         

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
@@ -216,18 +216,7 @@ public class EnterVariablesController
             groupList.add(new PopulatedDisplayGroup(varList, calculation.getPatient()));
         }
         
-        final VariableGroup medicationsGroup = new VariableGroup("Medications", 3);
-        // Check to see if the any groups are missing because of that group not having variables.
-        // Add the group with reference information if it is missing.
-        if(!map.containsKey(medicationsGroup))
-        {
-            groupList.add(new PopulatedDisplayGroup(medicationsGroup, calculation.getPatient()));
-        }
-        final VariableGroup clinicalConditionsGroup = new VariableGroup("Clinical Conditions or Diseases - Recent", 5);
-        if(!map.containsKey(clinicalConditionsGroup))
-        {
-            groupList.add(new PopulatedDisplayGroup(clinicalConditionsGroup, calculation.getPatient()));
-        }
+        ReferenceInfoAdder.addRefInfo(map, groupList, calculation.getPatient());
         // Finally, sort the List.
         Collections.sort(groupList);
         

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/controller/EnterVariablesController.java
@@ -216,6 +216,18 @@ public class EnterVariablesController
             groupList.add(new PopulatedDisplayGroup(varList, calculation.getPatient()));
         }
         
+        final VariableGroup medicationsGroup = new VariableGroup("Medications", 3);
+        // Check to see if the any groups are missing because of that group not having variables.
+        // Add the group with reference information if it is missing.
+        if(!map.containsKey(medicationsGroup))
+        {
+            groupList.add(new PopulatedDisplayGroup(medicationsGroup, calculation.getPatient()));
+        }
+        final VariableGroup clinicalConditionsGroup = new VariableGroup("Clinical Conditions or Diseases - Recent", 5);
+        if(!map.containsKey(clinicalConditionsGroup))
+        {
+            groupList.add(new PopulatedDisplayGroup(clinicalConditionsGroup, calculation.getPatient()));
+        }
         // Finally, sort the List.
         Collections.sort(groupList);
         

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/PopulatedDisplayGroup.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/PopulatedDisplayGroup.java
@@ -106,6 +106,10 @@ public final class PopulatedDisplayGroup implements Comparable<PopulatedDisplayG
         return fDisplayItems;
     }
     
+    /**
+     * Returns the {@link VariableGroup} that this PopulatedDisplayGroup bases its groupings off of
+     * for {@link DisplayItem}s
+     */
     public VariableGroup getGroup()
     {
         return fGroup;

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
@@ -12,8 +12,24 @@ import java.util.Map;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class ReferenceInfoAdder
+/**
+ * <p>A class used to add reference information to existing PopulatedDisplayGroups and create
+ * PopulatedDisplayGroups that do not exist, in order to store reference information to display
+ * for the user.</p>
+ * 
+ * <p>Per Effective Java Item 17, this class is marked final because it was not
+ * designed for inheritance.</p>
+ */
+public final class ReferenceInfoAdder
 {
+    /**
+     * Adds reference information for all of the given {@link PopulatedDisplayGroup}s and adds any groups
+     * that are missing in order to include their reference information as well.
+     * @param map a map where they key is a VariableGroup and the value is a List of Variables
+     *          that all belong to the same VariableGroup
+     * @param groupList a list of all previously existing PopulatedDisplayGroup
+     * @param patient the patient to add reference information from
+     */
     public static void addRefInfo(final Map<VariableGroup, List<Variable>> map, final List<PopulatedDisplayGroup> groupList,
             final Patient patient)
     {
@@ -22,7 +38,7 @@ public class ReferenceInfoAdder
         {
             addReferenceInfo(populatedGroup.getGroup(), populatedGroup, patient);
         }
-        final VariableGroup medicationsGroup = new VariableGroup("Medications", 3);
+        final VariableGroup medicationsGroup = new VariableGroup(VariableGroup.MEDICATIONS_GROUP, 3);
         // Check to see if the any groups are missing because of that group not having variables.
         // Add the group with reference information if it is missing.
         if(!map.containsKey(medicationsGroup))
@@ -31,7 +47,7 @@ public class ReferenceInfoAdder
             addReferenceInfo(medicationsGroup, populatedMedGroup, patient);
             groupList.add(populatedMedGroup);
         }
-        final VariableGroup clinicalConditionsGroup = new VariableGroup("Clinical Conditions or Diseases - Recent", 5);
+        final VariableGroup clinicalConditionsGroup = new VariableGroup(VariableGroup.CLINICAL_GROUP, 5);
         if(!map.containsKey(clinicalConditionsGroup))
         {
             final PopulatedDisplayGroup populatedClinicalGroup = new PopulatedDisplayGroup(clinicalConditionsGroup, patient);

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
@@ -1,0 +1,65 @@
+package gov.va.med.srcalc.web.view;
+
+import gov.va.med.srcalc.domain.HealthFactor;
+import gov.va.med.srcalc.domain.Patient;
+import gov.va.med.srcalc.domain.model.Variable;
+import gov.va.med.srcalc.domain.model.VariableGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+public class ReferenceInfoAdder
+{
+    public static void addRefInfo(final Map<VariableGroup, List<Variable>> map, final List<PopulatedDisplayGroup> groupList,
+            final Patient patient)
+    {
+        // Add reference information for existing groups.
+        for(final PopulatedDisplayGroup populatedGroup: groupList)
+        {
+            addReferenceInfo(populatedGroup.getGroup(), populatedGroup, patient);
+        }
+        final VariableGroup medicationsGroup = new VariableGroup("Medications", 3);
+        // Check to see if the any groups are missing because of that group not having variables.
+        // Add the group with reference information if it is missing.
+        if(!map.containsKey(medicationsGroup))
+        {
+            final PopulatedDisplayGroup populatedMedGroup = new PopulatedDisplayGroup(medicationsGroup, patient);
+            addReferenceInfo(medicationsGroup, populatedMedGroup, patient);
+            groupList.add(populatedMedGroup);
+        }
+        final VariableGroup clinicalConditionsGroup = new VariableGroup("Clinical Conditions or Diseases - Recent", 5);
+        if(!map.containsKey(clinicalConditionsGroup))
+        {
+            final PopulatedDisplayGroup populatedClinicalGroup = new PopulatedDisplayGroup(clinicalConditionsGroup, patient);
+            addReferenceInfo(clinicalConditionsGroup, populatedClinicalGroup, patient);
+            groupList.add(populatedClinicalGroup);
+        }
+    }
+    
+    private static void addReferenceInfo(final VariableGroup group,
+            final PopulatedDisplayGroup populatedGroup, final Patient patient)
+    {
+        // These group names are all well-known and are hard-coded as such.
+        if(group.getName().equalsIgnoreCase(VariableGroup.CLINICAL_GROUP))
+        {
+            final List<String> factorList = new ArrayList<String>();
+            // Output the date without the time of day.
+            final DateTimeFormatter format = DateTimeFormat.forPattern("MM/dd/yy");
+            for(final HealthFactor factor: patient.getHealthFactors())
+            {
+                factorList.add(String.format("%s %s%n", format.print(factor.getDate()), factor.getName()));
+            }
+            final DisplayItem refInfo = new ReferenceItem("Health Factors", group, factorList);
+            populatedGroup.getDisplayItems().add(0, refInfo);
+        }
+        else if(group.getName().equalsIgnoreCase(VariableGroup.MEDICATIONS_GROUP))
+        {
+            populatedGroup.getDisplayItems().add(0, 
+                    new ReferenceItem("Active Medications", group, patient.getActiveMedications()));
+        }
+    }
+}

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/ReferenceInfoAdder.java
@@ -2,12 +2,10 @@ package gov.va.med.srcalc.web.view;
 
 import gov.va.med.srcalc.domain.HealthFactor;
 import gov.va.med.srcalc.domain.Patient;
-import gov.va.med.srcalc.domain.model.Variable;
 import gov.va.med.srcalc.domain.model.VariableGroup;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -30,8 +28,7 @@ public final class ReferenceInfoAdder
      * @param groupList a list of all previously existing PopulatedDisplayGroup
      * @param patient the patient to add reference information from
      */
-    public static void addRefInfo(final Map<VariableGroup, List<Variable>> map, final List<PopulatedDisplayGroup> groupList,
-            final Patient patient)
+    public static void addRefInfo(final List<PopulatedDisplayGroup> groupList, final Patient patient)
     {
         // Add reference information for existing groups.
         for(final PopulatedDisplayGroup populatedGroup: groupList)
@@ -41,19 +38,31 @@ public final class ReferenceInfoAdder
         final VariableGroup medicationsGroup = new VariableGroup(VariableGroup.MEDICATIONS_GROUP, 3);
         // Check to see if the any groups are missing because of that group not having variables.
         // Add the group with reference information if it is missing.
-        if(!map.containsKey(medicationsGroup))
+        if(!doesGroupExist(groupList, medicationsGroup))
         {
             final PopulatedDisplayGroup populatedMedGroup = new PopulatedDisplayGroup(medicationsGroup, patient);
             addReferenceInfo(medicationsGroup, populatedMedGroup, patient);
             groupList.add(populatedMedGroup);
         }
         final VariableGroup clinicalConditionsGroup = new VariableGroup(VariableGroup.CLINICAL_GROUP, 5);
-        if(!map.containsKey(clinicalConditionsGroup))
+        if(!doesGroupExist(groupList,clinicalConditionsGroup))
         {
             final PopulatedDisplayGroup populatedClinicalGroup = new PopulatedDisplayGroup(clinicalConditionsGroup, patient);
             addReferenceInfo(clinicalConditionsGroup, populatedClinicalGroup, patient);
             groupList.add(populatedClinicalGroup);
         }
+    }
+    
+    private static boolean doesGroupExist(final List<PopulatedDisplayGroup> groupList, final VariableGroup varGroup)
+    {
+        for(final PopulatedDisplayGroup currentGroup: groupList)
+        {
+            if(currentGroup.getName().equals(varGroup.getName()))
+            {
+                return true;
+            }
+        }
+        return false;
     }
     
     private static void addReferenceInfo(final VariableGroup group,

--- a/srcalc/src/main/webapp/WEB-INF/views/fragments/referenceItem.jsp
+++ b/srcalc/src/main/webapp/WEB-INF/views/fragments/referenceItem.jsp
@@ -3,7 +3,14 @@
 <%-- This file cannot be a jspf extension because it is not included statically. --%>
 <%-- This jsp expects for displayItemParam to be defined. --%>
 <ul class="patientNote">
-<c:forEach var="item" items="${displayItemParam.referenceInfo}">
-    <li>${item}</li>
-</c:forEach>
+    <c:choose>
+	<c:when test="${empty displayItemParam.referenceInfo}">
+        <li>None</li>
+	</c:when>
+	<c:otherwise>
+	    <c:forEach var="item" items="${displayItemParam.referenceInfo}">
+            <li>${item}</li>
+        </c:forEach>
+	</c:otherwise>
+	</c:choose>
 </ul>

--- a/srcalc/src/main/webapp/WEB-INF/views/fragments/referenceItem.jsp
+++ b/srcalc/src/main/webapp/WEB-INF/views/fragments/referenceItem.jsp
@@ -4,13 +4,14 @@
 <%-- This jsp expects for displayItemParam to be defined. --%>
 <ul class="patientNote">
     <c:choose>
-	<c:when test="${empty displayItemParam.referenceInfo}">
+    <c:when test="${empty displayItemParam.referenceInfo}">
         <li>None</li>
-	</c:when>
-	<c:otherwise>
-	    <c:forEach var="item" items="${displayItemParam.referenceInfo}">
+    </c:when>
+    <c:otherwise>
+        <c:forEach var="item"
+            items="${displayItemParam.referenceInfo}">
             <li>${item}</li>
         </c:forEach>
-	</c:otherwise>
-	</c:choose>
+    </c:otherwise>
+    </c:choose>
 </ul>

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/PopulatedDisplayGroupTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/calculation/PopulatedDisplayGroupTest.java
@@ -36,15 +36,21 @@ public class PopulatedDisplayGroupTest
                 SampleModels.genderVariable());
         final Patient patient = SampleCalculations.dummyPatient(1);
         patient.getHealthFactors().add(new HealthFactor(LocalDate.now(), "Dummy health factor"));
+        // Test a PopulatedDisplayGroup with only variables
         final PopulatedDisplayGroup group = new PopulatedDisplayGroup(variables, patient);
+        // Test a PopulatedDisplayGroup with variables and reference information
         final PopulatedDisplayGroup group2 = new PopulatedDisplayGroup(
                 Arrays.asList(SampleModels.functionalStatusVariable()), patient);
+        // Test a PopulatedDisplayGroup with only reference information
+        final PopulatedDisplayGroup group3 = new PopulatedDisplayGroup(
+                SampleModels.medicationsVariableGroup(), patient);
         assertEquals(
                 "Display Group 'Demographics' with display items [Age, Gender]",
                 group.toString());
         // Make sure the toString works with reference information too.
         assertEquals("Display Group 'Clinical Conditions or Diseases - Recent' with display items [Health Factors, Functional Status]",
                 group2.toString());
+        assertEquals("Display Group 'Medications' with display items [Active Medications]", group3.toString());
     }
     
     @Test

--- a/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/domain/model/SampleModels.java
@@ -217,6 +217,11 @@ public class SampleModels
         return makeVariableGroup("Demographics", 1);
     }
     
+    public static VariableGroup medicationsVariableGroup()
+    {
+        return makeVariableGroup("Medications", 3);
+    }
+    
     public static VariableGroup labVariableGroup()
     {
         return makeVariableGroup("Laboratory Values", 4);

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPatientDaoTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPatientDaoTest.java
@@ -39,6 +39,9 @@ public class RpcVistaPatientDaoTest
     private final static List<String> VALID_HEALTH_FACTORS = ImmutableList.of("08/25/2014^REFUSED INFLUENZA IMMUNIZATION",
             "08/22/2014^DEPRESSION ASSESS POSITIVE (MDD)","08/22/2014^REFUSED INFLUENZA IMMUNIZATION",
             "08/20/2014^ALCOHOL - TREATMENT REFERRAL","08/08/2014^CURRENT SMOKER","07/30/2014^GEC HOMELESS");
+    private final static List<String> VALID_ACTIVE_MEDICATIONS = ImmutableList.of(
+            "403962R;O^METOPROLOL TARTRATE 50MG TAB^3110228^^^3",
+            "404062R;O^SIMVASTATIN 40MG TAB^3110228^^^3");
     
     private final static int PATIENT_DFN = 500;
 
@@ -201,5 +204,30 @@ public class RpcVistaPatientDaoTest
         final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
         final Patient patient = dao.getPatient(PATIENT_DFN);
         assertEquals(Collections.<HealthFactor>emptyList(), patient.getHealthFactors());
+    }
+    
+    @Test
+    public final void testMedicationsValid()
+    {
+        final VistaProcedureCaller caller = mockVistaProcedureCaller();
+        when(caller.doRpc(
+                RADIOLOGIST_DUZ,
+                RemoteProcedure.GET_ACTIVE_MEDICATIONS,
+                String.valueOf(PATIENT_DFN), "", ""))
+                .thenReturn(VALID_ACTIVE_MEDICATIONS);
+        final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
+        final Patient patient = dao.getPatient(PATIENT_DFN);
+        final List<String> expectedMedications = ImmutableList.of(
+                "METOPROLOL TARTRATE 50MG TAB", "SIMVASTATIN 40MG TAB");
+        assertEquals(expectedMedications, patient.getActiveMedications());
+    }
+    
+    @Test
+    public final void testNoMedications()
+    {
+        final VistaProcedureCaller caller = mockVistaProcedureCaller();
+        final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
+        final Patient patient = dao.getPatient(PATIENT_DFN);
+        assertEquals(Collections.<String>emptyList(), patient.getActiveMedications());
     }
 }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPatientDaoTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/RpcVistaPatientDaoTest.java
@@ -207,6 +207,20 @@ public class RpcVistaPatientDaoTest
     }
     
     @Test
+    public final void testInvalidHealthFactor()
+    {
+        final VistaProcedureCaller caller = mockVistaProcedureCaller();
+        when(caller.doRpc(
+                RADIOLOGIST_DUZ,
+                RemoteProcedure.GET_HEALTH_FACTORS,
+                String.valueOf(PATIENT_DFN)))
+                .thenReturn(ImmutableList.of("Invalid health factors String."));
+        final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
+        final Patient patient = dao.getPatient(PATIENT_DFN);
+        assertEquals(Collections.<HealthFactor>emptyList(), patient.getHealthFactors());
+    }
+    
+    @Test
     public final void testMedicationsValid()
     {
         final VistaProcedureCaller caller = mockVistaProcedureCaller();
@@ -226,6 +240,20 @@ public class RpcVistaPatientDaoTest
     public final void testNoMedications()
     {
         final VistaProcedureCaller caller = mockVistaProcedureCaller();
+        final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
+        final Patient patient = dao.getPatient(PATIENT_DFN);
+        assertEquals(Collections.<String>emptyList(), patient.getActiveMedications());
+    }
+    
+    @Test
+    public final void testInvalidMedications()
+    {
+        final VistaProcedureCaller caller = mockVistaProcedureCaller();
+        when(caller.doRpc(
+                RADIOLOGIST_DUZ,
+                RemoteProcedure.GET_ACTIVE_MEDICATIONS,
+                String.valueOf(PATIENT_DFN)))
+                .thenReturn(ImmutableList.of("Invalid medications String."));
         final RpcVistaPatientDao dao = new RpcVistaPatientDao(caller, RADIOLOGIST_DUZ);
         final Patient patient = dao.getPatient(PATIENT_DFN);
         assertEquals(Collections.<String>emptyList(), patient.getActiveMedications());

--- a/srcalc/src/test/java/gov/va/med/srcalc/web/view/PopulatedDisplayGroupTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/web/view/PopulatedDisplayGroupTest.java
@@ -39,11 +39,9 @@ public class PopulatedDisplayGroupTest
                 Arrays.asList(SampleModels.functionalStatusVariable()), patient);
         final List<PopulatedDisplayGroup> groupList = new ArrayList<PopulatedDisplayGroup>();
         groupList.add(group);
-        final Map<VariableGroup, List<Variable>> groupMap = new HashMap<VariableGroup, List<Variable>>();
         final List<Variable> varList = new ArrayList<Variable>();
         varList.add(SampleModels.functionalStatusVariable());
-        groupMap.put(group.getGroup(), varList);
-        ReferenceInfoAdder.addRefInfo(groupMap, groupList, patient);
+        ReferenceInfoAdder.addRefInfo(groupList, patient);
         assertEquals("Display Group 'Clinical Conditions or Diseases - Recent' with display items [Health Factors, Functional Status]",
                 group.toString());
     }
@@ -87,7 +85,7 @@ public class PopulatedDisplayGroupTest
         assertEquals(0, group.getDisplayItems().size());
         final List<PopulatedDisplayGroup> groupList = new ArrayList<PopulatedDisplayGroup>();
         groupList.add(group);
-        ReferenceInfoAdder.addRefInfo(Collections.<VariableGroup, List<Variable>> emptyMap(), groupList, patient);
+        ReferenceInfoAdder.addRefInfo(groupList, patient);
         assertEquals(1, group.getDisplayItems().size());
     }
 }


### PR DESCRIPTION
Active medications now display properly on the Enter Variables pages. If any reference item is empty, the page will display "None" in place of that empty list.