### PR TITLE
ASRC-232: revert eager-loading RiskModels

### DIFF
--- a/srcalc/src/main/java/gov/va/med/srcalc/db/SpecialtyDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/SpecialtyDao.java
@@ -1,15 +1,21 @@
 package gov.va.med.srcalc.db;
 
+import gov.va.med.srcalc.domain.model.Specialty;
+import gov.va.med.srcalc.domain.model.Variable;
+
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
-import gov.va.med.srcalc.domain.model.*;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Data Access Object (DAO) for {@link Specialty} objects.
@@ -17,6 +23,8 @@ import gov.va.med.srcalc.domain.model.*;
 @Repository
 public class SpecialtyDao
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpecialtyDao.class);
+    
     private final SessionFactory fSessionFactory;
     
     @Inject // Allow arguments to be autowired.
@@ -62,9 +70,33 @@ public class SpecialtyDao
         return s;
     }
 
+    /**
+     * Returns all Specialties in the database.
+     * @return a List ordered by Specialty name
+     */
     @SuppressWarnings("unchecked") // trust Hibernate
     public List<Specialty> getAllSpecialties()
     {
         return getCurrentSession().createQuery("from Specialty s order by s.name").list();
+    }
+    
+    /**
+     * Returns all Specialties with the RiskModels fully loaded (as opposed to lazy
+     * proxies).
+     * @return a List ordered by Specialty name
+     */
+    public ImmutableList<Specialty> getAllSpecialtiesWithRiskModels()
+    {
+        // We could try to do a join fetch here, but RiskModels require so much joining
+        // (and there are so few specialties) that we just do N+1 selects.
+        final List<Specialty> specialties = getAllSpecialties();
+        LOGGER.debug("Specialties loaded, now loading associated RiskModels...");
+        for (final Specialty s : specialties)
+        {
+            // Yes, this is coupling to Hibernate outside the db package, but this keeps
+            // it straightforward and simple.
+            Hibernate.initialize(s.getRiskModels());
+        }
+        return ImmutableList.copyOf(specialties);
     }
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/domain/model/Specialty.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/domain/model/Specialty.java
@@ -137,13 +137,9 @@ public final class Specialty implements Serializable
     }
     
     /**
-     * Returns all {@link RiskModel}s associated with the Specialty. 
-     * Note that these are fetched eagerly. If not then there is an
-     * issue when this method is called outside of a valid transaction.
-     *    This is the easiest solution since this table is small. If 
-     * it were large then this could be a performance issue. 
+     * Returns all {@link RiskModel}s associated with the Specialty. Caution: lazy-loaded.
      */
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.LAZY)
     // Override strange defaults. See
     // <https://forum.hibernate.org/viewtopic.php?f=1&t=1037190>.
     @JoinTable(

--- a/srcalc/src/main/java/gov/va/med/srcalc/service/DefaultAdminService.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/service/DefaultAdminService.java
@@ -10,6 +10,7 @@ import gov.va.med.srcalc.domain.model.*;
 
 import javax.inject.Inject;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
@@ -122,7 +123,14 @@ public class DefaultAdminService implements AdminService
     public List<Specialty> getAllSpecialties()
     {
         LOGGER.debug("Getting all Specialties.");
-        return fSpecialtyDao.getAllSpecialties();
+        final List<Specialty> specialties = fSpecialtyDao.getAllSpecialties();
+        for (final Specialty s : specialties)
+        {
+            // Yes, this is coupling to Hibernate outside the db package, but this keeps
+            // it straightforward and simple.
+            Hibernate.initialize(s.getRiskModels());
+        }
+        return specialties;
     }
     
     @Override

--- a/srcalc/src/main/java/gov/va/med/srcalc/service/DefaultAdminService.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/service/DefaultAdminService.java
@@ -10,7 +10,6 @@ import gov.va.med.srcalc.domain.model.*;
 
 import javax.inject.Inject;
 
-import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
@@ -123,14 +122,7 @@ public class DefaultAdminService implements AdminService
     public List<Specialty> getAllSpecialties()
     {
         LOGGER.debug("Getting all Specialties.");
-        final List<Specialty> specialties = fSpecialtyDao.getAllSpecialties();
-        for (final Specialty s : specialties)
-        {
-            // Yes, this is coupling to Hibernate outside the db package, but this keeps
-            // it straightforward and simple.
-            Hibernate.initialize(s.getRiskModels());
-        }
-        return specialties;
+        return fSpecialtyDao.getAllSpecialtiesWithRiskModels();
     }
     
     @Override

--- a/srcalc/src/main/java/gov/va/med/srcalc/service/ModelInspectionService.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/service/ModelInspectionService.java
@@ -76,7 +76,8 @@ public interface ModelInspectionService
     public RiskModel getRiskModelForId(int modelId);
     
     /**
-     * Get a list of all (@link Specialty) objects in the database.
+     * Get a list of all (@link Specialty) objects in the database. All associated
+     * {@link RiskModel}s, which are normally lazy-loaded, will be loaded as well.
      * @return a list ordered by name. 
      */
     public List<Specialty> getAllSpecialties();

--- a/srcalc/src/test/java/gov/va/med/srcalc/service/AdminServiceIT.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/service/AdminServiceIT.java
@@ -189,6 +189,9 @@ public class AdminServiceIT extends IntegrationTest
     public final void testGetAllSpecialties() 
     {
         List<Specialty> specList = fAdminService.getAllSpecialties();
+        
+        // Simulate a new Session to ensure the risk models are actually loaded.
+        simulateNewSession();
 
         assertEquals( 7, specList.size() );
         assertEquals( "Cardiac", specList.get(0).getName() );
@@ -198,5 +201,7 @@ public class AdminServiceIT extends IntegrationTest
         assertEquals( "Thoracic", specList.get(4).getName() );
         assertEquals( "Urology", specList.get(5).getName() );
         assertEquals( "Vascular", specList.get(6).getName() );
+        // Ensure RiskModels are loaded.
+        assertEquals(1, specList.get(0).getRiskModels().size());
     }
 }


### PR DESCRIPTION
to avoid a large amounts of SELECT statements whenever we load all specialties.

This improves performance, but the main driver for this change is to avoid polluting the logs with these meaningless statements.