### PR TITLE
ASRC-59: raise utilization report max results to 400,000

### DIFF
--- a/srcalc/build.gradle
+++ b/srcalc/build.gradle
@@ -35,6 +35,10 @@ configurations {
     // exclude the old 2.x versions.
     all*.exclude group: 'javax.servlet', module: 'servlet-api'
     
+    // slf4j-ext has a compile-time dependence on cal10n-api, but we don't use that part
+    // of the library. Since cal10n-api causes a compiler warning, exclude it.
+    all*.exclude group: 'ch.qos.cal10n', module: 'cal10n-api'
+    
     all {
         resolutionStrategy {
             // jadira usertype.core includes this dependency, which bumps the Hibernate
@@ -75,6 +79,8 @@ dependencies {
 	/* Other libraries */
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+    // Note: see cal10n-api exclusion above.
+    compile group: 'org.slf4j', name: 'slf4j-ext', version: slf4jVersion
     compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: slf4jVersion
     compile group: 'org.hibernate', name: 'hibernate-core', version: hibernateVersion
 	compile group: 'org.springframework', name: 'spring-core', version: springVersion

--- a/srcalc/src/main/java/gov/va/med/srcalc/db/HistoricalSearchParameters.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/HistoricalSearchParameters.java
@@ -3,7 +3,6 @@ package gov.va.med.srcalc.db;
 import java.util.Objects;
 
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.joda.time.LocalDate;
 
@@ -28,7 +27,7 @@ public final class HistoricalSearchParameters
     /**
      * The maximum number of results a search will return.
      */
-    public static final int MAX_RESULTS = 1000;
+    public static final int MAX_RESULTS = 400000;
     
     /**
      * The description of the minDate parameter: {@value}.
@@ -95,7 +94,6 @@ public final class HistoricalSearchParameters
     {
         final DetachedCriteria criteria =
                 DetachedCriteria.forClass(HistoricalCalculation.class);
-        criteria.addOrder(Order.desc("startTimestamp"));
         
         if (fMinDate.isPresent())
         {

--- a/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
@@ -136,6 +136,8 @@ public class ResultsDao
         /* First get the matching HistoricalCalculation objects. */
         final Criteria historicalCriteria = baseHistoricalCriteria
                 .getExecutableCriteria(session)
+                // The easiest way to detect running into the maximum is to actually query
+                // for an extra one and see if we get it.
                 .setMaxResults(HistoricalSearchParameters.MAX_RESULTS + 1);
         historicalCriteria.addOrder(Order.desc("startTimestamp"));
         LOGGER.trace("Doing HistoricalCalculation search with Criteria {}.",

--- a/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/ResultsDao.java
@@ -12,10 +12,12 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.profiler.Profiler;
 import org.springframework.stereotype.Repository;
 
 import com.google.common.base.Optional;
@@ -124,14 +126,18 @@ public class ResultsDao
             final HistoricalSearchParameters parameters)
     {
         LOGGER.debug("Doing HistoricalRunInfo query with parameters {}.", parameters);
+        final Profiler profiler = new Profiler("historicalRunInfo query");
+        profiler.setLogger(LOGGER);
 
+        profiler.start("HistoricalCalculation search");
         final DetachedCriteria baseHistoricalCriteria = parameters.makeCriteria();
         final Session session = getCurrentSession();
         
         /* First get the matching HistoricalCalculation objects. */
         final Criteria historicalCriteria = baseHistoricalCriteria
                 .getExecutableCriteria(session)
-                .setMaxResults(HistoricalSearchParameters.MAX_RESULTS);
+                .setMaxResults(HistoricalSearchParameters.MAX_RESULTS + 1);
+        historicalCriteria.addOrder(Order.desc("startTimestamp"));
         LOGGER.trace("Doing HistoricalCalculation search with Criteria {}.",
                 historicalCriteria);
         @SuppressWarnings("unchecked") // trust Hibernate
@@ -141,6 +147,7 @@ public class ResultsDao
          * Now get any associated SignedResult objects. (If there are n
          * HistoricalCalculations, there will be <= n of these.)
          */
+        profiler.start("SignedResult search");
         // Just select the Id from the HistoricalCalculations for the in() subquery.
         // Hibernate requires this though it could probably do it automatically. (See
         // HHH-993.)
@@ -153,7 +160,9 @@ public class ResultsDao
         final List<SignedResult> results = resultCriteria.list();
         
         /* Now merge the two into HistoricalRunInfo objects. */
+        profiler.start("makeRunInfos");
         final ImmutableList<HistoricalRunInfo> runInfos = makeRunInfos(historicals, results);
+        profiler.stop().log();
 
         return SearchResults.fromList(runInfos, HistoricalSearchParameters.MAX_RESULTS);
     }

--- a/srcalc/src/main/java/gov/va/med/srcalc/db/SpecialtyDao.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/db/SpecialtyDao.java
@@ -39,8 +39,8 @@ public class SpecialtyDao
     }
     
     /**
-     * Returns the Specialty from the Database with the given name. The Specialty
-     * will have all of the associated {@link RiskModel}s loaded from the DB.
+     * Returns the Specialty from the Database with the given name. The Specialty will
+     * have all of the associated RiskModels loaded from the DB.
      * @return the Specialty object or null if there was no specialty with the
      * given name
      */

--- a/srcalc/src/main/java/gov/va/med/srcalc/util/SearchResults.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/util/SearchResults.java
@@ -73,7 +73,8 @@ public final class SearchResults<T>
     {
         return MoreObjects.toStringHelper(this)
                 .add("truncated", fTruncated)
-                .add("foundItems", fFoundItems)
+                // Don't include the whole list as it may have thousands of items.
+                .add("#ofItems", fFoundItems.size())
                 .toString();
     }
     

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/controller/admin/UtilizationReportController.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/controller/admin/UtilizationReportController.java
@@ -25,7 +25,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class UtilizationReportController
 {
     /**
-     * The attribute name of the {@link ResultSearchParameters} object.
+     * The attribute name of the {@link HistoricalSearchParameters} object.
      */
     public static final String ATTRIBUTE_REPORT_PARAMETERS = "reportParameters";
     

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationReport.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationReport.java
@@ -10,7 +10,9 @@ import gov.va.med.srcalc.domain.calculation.HistoricalRunInfo;
 import gov.va.med.srcalc.util.SearchResults;
 
 /**
- * <p>Encapsulates Utilization Report data.</p>
+ * <p>Encapsulates Utilization Report data. Even though we only display the summary
+ * statistics on the UI, we still store the full results since they are available
+ * anyway.</p>
  * 
  * <p>The references in this class cannot be changed, but it is not truly immutable
  * because {@link HistoricalSearchParameters} is mutable.</p>

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationReport.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationReport.java
@@ -29,7 +29,7 @@ public final class UtilizationReport
     
     /**
      * Constructs an instance with the given properties and a generationDate of now.
-     * @param parameters See {@link #getParameters()}.
+     * @param params See {@link #getParameters()}.
      * @param results See {@link #getResults()}.
      * @throws NullPointerException if any argument is null
      */

--- a/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationSummary.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/web/view/admin/UtilizationSummary.java
@@ -107,7 +107,7 @@ public final class UtilizationSummary
     }
     
     /**
-     * Returns the mean of {@link SignedResult#getSecondsToSignature()}. If there are no
+     * Returns the mean of {@link SignedResult#getSecondsToSign()}. If there are no
      * signed calculations, returns -1. (Normally we would use an {@link
      * com.google.common.base.Optional Optional} for this, but it is not EL-friendly.)
      */

--- a/srcalc/src/main/webapp/WEB-INF/views/admin/utilizationReportResults.jsp
+++ b/srcalc/src/main/webapp/WEB-INF/views/admin/utilizationReportResults.jsp
@@ -25,12 +25,12 @@
     </ul>
     
     <p>
-    The below tables may be copied and pasted into Excel.
+    The below table may be copied and pasted into Excel.
     </p>
     
     <c:if test="${report.results.truncated}">
     <p class="error">
-    Your search returned more results than could be displayed. Please refine your search.
+    Your search returned more results than could be analyzed. Please refine your search.
     </p>
     </c:if>
     
@@ -64,46 +64,6 @@
         <c:if test="${summaryEntry.value.secondsToSignAverage >= 0}">
         <fmt:formatNumber
             value="${summaryEntry.value.secondsToSignAverage / 60}"
-            minFractionDigits="1" maxFractionDigits="1"/>
-        </c:if>
-        </td>
-    </tr>
-    </c:forEach>
-    </tbody>
-    </table>
-    
-    <h3>Calculation Data</h3>
-    
-    <table id="utilizationReportTable" class="srcalcTable reportTable">
-    <thead>
-    <tr>
-        <th>Specialty</th>
-        <th>Date</th>
-        <th>Signed</th>
-        <th>Time to First Run<br>(Minutes)</th>
-        <th>Time to Sign<br>(Minutes)</th>
-    </tr>
-    </thead>
-    <tbody>
-    <c:forEach var="foundItem" items="${report.results.foundItems}">
-    <tr>
-        <td>
-        <c:out value="${foundItem.historicalCalculation.specialtyName}"/>
-        </td>
-        <td>
-        <joda:format value="${foundItem.historicalCalculation.startTimestamp}"
-            pattern="yyyy-MM-dd"/>
-        </td>
-        <td>${foundItem.signed ? "Yes" : "No"}</td>
-        <td class="numerical">
-        <fmt:formatNumber
-            value="${foundItem.historicalCalculation.secondsToFirstRun / 60}"
-            minFractionDigits="1" maxFractionDigits="1"/>
-        </td>
-        <td class="numerical">
-        <c:if test="${foundItem.signed}">
-        <fmt:formatNumber
-            value="${foundItem.signedResultNullable.secondsToSign / 60}"
             minFractionDigits="1" maxFractionDigits="1"/>
         </c:if>
         </td>


### PR DESCRIPTION
This allows the user to generate a utilitzation report with the needed data set
size. Note that we removed the detail rows from the report because obviously a
400,000-row table would be a little large.

If you need some test data for this, there is a CSV to do a batch import on Sharepoint.