### PR TITLE
ASRC-3 fix: fix an initialization issue

### DIFF
--- a/srcalc/build.gradle
+++ b/srcalc/build.gradle
@@ -71,6 +71,8 @@ dependencies {
     // These VistALink JARs represent the dependency on the VistALink Connector,
     // which must be deployed before this application.
     providedCompile files('../lib/vljFoundationsLib-1.6.0.028.jar', '../lib/vljConnector-1.6.0.028.jar')
+    // VistALink dependency:
+    providedCompile 'org.apache.xmlbeans:xmlbeans:2.3.0'
 
     // Give Eclipse the JSTL TLDs. They aren't included in the javaee-web-api
     // JAR.

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCaller.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCaller.java
@@ -86,7 +86,7 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
             fVlcf = (VistaLinkConnectionFactory)namingContext.lookup(
                     fVlcfJndiName);
         }
-        catch (NamingException e)
+        catch (final NamingException e)
         {
             throw new ConfigurationException(
                     "Could not load VistaLinkConnectionFactory from JNDI", e);
@@ -316,7 +316,7 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
      * either standard Java or Spring exceptions.
      * @param connectionSpec specifies connection parameters (e.g., division, user)
      * @param request specifies the remote procedure call to make
-     * @return an immutable list of String lines from the reponse
+     * @return an immutable list of String lines from the response
      * @throws DataAccessException if there was an error communicating with VistA
      * @throws AccountNotFoundException if the given ConnectionSpec specified a user
      * identifier (e.g., DUZ) that could not be matched to a VistA user

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCaller.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCaller.java
@@ -1,6 +1,8 @@
 package gov.va.med.srcalc.vista.vistalink;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.naming.*;
 import javax.resource.ResourceException;
@@ -13,9 +15,6 @@ import gov.va.med.srcalc.ConfigurationException;
 import gov.va.med.srcalc.vista.RemoteProcedure;
 import gov.va.med.srcalc.vista.VistaProcedureCaller;
 import gov.va.med.vistalink.adapter.cci.*;
-import gov.va.med.vistalink.institution.InstitutionMapNotInitializedException;
-import gov.va.med.vistalink.institution.InstitutionMappingDelegate;
-import gov.va.med.vistalink.institution.InstitutionMappingNotFoundException;
 import gov.va.med.vistalink.rpc.*;
 import gov.va.med.vistalink.security.m.SecurityAccessVerifyCodePairInvalidException;
 import gov.va.med.vistalink.security.m.SecurityFaultException;
@@ -24,6 +23,9 @@ import gov.va.med.vistalink.security.m.SecurityIdentityDeterminationFaultExcepti
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.*;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 /**
  * <p>Provides a simple interface to call VistA Remote Procedures. Uses VistALink.</p>
@@ -72,25 +74,22 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
         
         try
         {
-            fVlcfJndiName = InstitutionMappingDelegate.getJndiConnectorNameForInstitution(
-                    division);
+            final Optional<String> jndiName = VistaLinkUtil.getJndiNameForDivision(division);
+            if (!jndiName.isPresent())
+            {
+                throw new IllegalArgumentException(
+                        "Division " + division + " not supported");
+            }
+                   
+            fVlcfJndiName = jndiName.get();
             final Context namingContext = new InitialContext();
             fVlcf = (VistaLinkConnectionFactory)namingContext.lookup(
                     fVlcfJndiName);
-        }
-        catch (InstitutionMappingNotFoundException e)
-        {
-            throw new IllegalArgumentException("Division " + division + " not supported", e);
         }
         catch (NamingException e)
         {
             throw new ConfigurationException(
                     "Could not load VistaLinkConnectionFactory from JNDI", e);
-        }
-        catch (InstitutionMapNotInitializedException e)
-        {
-            throw new ConfigurationException(
-                    "VistALink institution map not loaded.", e);
         }
     }
     
@@ -317,7 +316,7 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
      * either standard Java or Spring exceptions.
      * @param connectionSpec specifies connection parameters (e.g., division, user)
      * @param request specifies the remote procedure call to make
-     * @return an unmodifiable list of String lines from the reponse
+     * @return an immutable list of String lines from the reponse
      * @throws DataAccessException if there was an error communicating with VistA
      * @throws AccountNotFoundException if the given ConnectionSpec specified a user
      * identifier (e.g., DUZ) that could not be matched to a VistA user
@@ -325,7 +324,7 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
      * code pair but it was not correct
      * @throws LoginException if any other issue occurred reauthenticating in VistA
      */
-    private List<String> doRpc(
+    private ImmutableList<String> doRpc(
             final VistaLinkConnectionSpec connectionSpec, final RpcRequest request)
             throws DataAccessException, FailedLoginException, AccountNotFoundException,
                     LoginException
@@ -346,9 +345,9 @@ public final class VistaLinkProcedureCaller implements VistaProcedureCaller
                     // String.split() is used here instead of Guava's Splitter 
                     // because it eliminates an empty string at the end of the 
                     // response result, which is the desired behavior.
-                    return Arrays.asList(response.getResults().split("\n"));
+                    return ImmutableList.copyOf(response.getResults().split("\n"));
                 }
-                return Arrays.asList(response.getResults());
+                return ImmutableList.of(response.getResults());
             }
             finally
             {

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtil.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtil.java
@@ -1,8 +1,15 @@
 package gov.va.med.srcalc.vista.vistalink;
 
-import gov.va.med.vistalink.institution.InstitutionMapNotInitializedException;
-import gov.va.med.vistalink.institution.InstitutionMappingDelegate;
-import gov.va.med.vistalink.institution.InstitutionMappingNotFoundException;
+import javax.naming.InitialContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+
+import gov.va.med.srcalc.ConfigurationException;
+import gov.va.med.vistalink.adapter.spi.ConfigurationReader;
+import gov.va.med.vistalink.institution.*;
 
 /**
  * Provides VistALink utility methods. These are not srcalc-specific: VistALink could have
@@ -10,9 +17,96 @@ import gov.va.med.vistalink.institution.InstitutionMappingNotFoundException;
  */
 public class VistaLinkUtil
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VistaLinkUtil.class);
+    
+    private static final IPrimaryStationRules STATION_RULES;
+    
+    // Eagerly get IPrimaryStationRules implementation to find configuration issues early.
+    static
+    {
+        try
+        {
+            STATION_RULES = PrimaryStationRulesFactory.getPrimaryStationRulesImplementation();
+        }
+        catch (final ReflectiveOperationException e)
+        {
+            // getPrimaryStationRulesImplementation() does not document its exceptions,
+            // so at least be as specific as we can.
+            throw new ConfigurationException(
+                    "Could not get configured IPrimaryStationRules implementation.", e);
+        }
+    }
+    
     private VistaLinkUtil()
     {
         // No construction.
+    }
+    
+    private static String getStationFromDivision(final String division)
+        throws InstitutionMappingBadStationNumberException
+    {
+        return STATION_RULES.getPrimaryStationLookupString(division);
+    }
+    
+    private static void tryForceLoad(final String division)
+    {
+        try
+        {
+            final String station = getStationFromDivision(division);
+            final String configuredJndiName =
+                    ConfigurationReader.getJndiNameForStationNumber(station);
+            LOGGER.trace(
+                    "Got JNDI name {} for division {} from configuration",
+                    configuredJndiName, division);
+            if (configuredJndiName != null)
+            {
+                final InitialContext ic = new InitialContext();
+                ic.lookup(configuredJndiName);
+            }
+        }
+        catch (final Exception ex)
+        {
+            LOGGER.info(
+                    "Swallowing Exception while trying to force-load division {}",
+                    division,
+                    ex);
+        }
+    }
+    
+    /**
+     * Returns the JNDI name of the VistALink ConnectionFactory for the given division,
+     * if known.
+     */
+    public static Optional<String> getJndiNameForDivision(final String division)
+    {
+        try
+        {
+            return Optional.of(
+                    InstitutionMappingDelegate.getJndiConnectorNameForInstitution(division));
+        }
+        catch (InstitutionMapNotInitializedException |
+                InstitutionMappingNotFoundException ex)
+        {
+            /*
+             * This isn't pretty: VistALink relies on the connectors being eagerly-loaded
+             * like WebLogic does, but it isn't standard across application servers. The
+             * VistALink code contains the below hack to force initialization but for some
+             * reason only enables it on Websphere.
+             */
+            tryForceLoad(division);
+
+            try
+            {
+                return Optional.of(
+                        InstitutionMappingDelegate.getJndiConnectorNameForInstitution(division));
+            }
+            catch (InstitutionMapNotInitializedException |
+                    InstitutionMappingNotFoundException e)
+            {
+                LOGGER.debug("Unknown division {}", division, e);
+                return Optional.absent();
+            }
+        }
     }
 
     /**
@@ -20,16 +114,7 @@ public class VistaLinkUtil
      */
     public static boolean isDivisionKnown(final String division)
     {
-        try
-        {
-            InstitutionMappingDelegate.getJndiConnectorNameForInstitution(division);
-        }
-        catch (InstitutionMapNotInitializedException | InstitutionMappingNotFoundException e)
-        {
-            return false;
-        }
-        
-        return true;
+        return getJndiNameForDivision(division).isPresent();
     }
     
 }

--- a/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtil.java
+++ b/srcalc/src/main/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtil.java
@@ -42,17 +42,17 @@ public class VistaLinkUtil
         // No construction.
     }
     
-    private static String getStationFromDivision(final String division)
-        throws InstitutionMappingBadStationNumberException
-    {
-        return STATION_RULES.getPrimaryStationLookupString(division);
-    }
-    
+    /**
+     * Tries to load the VistALink ConnectionFactory for the given division by explicitly
+     * reading the configuration file.
+     */
     private static void tryForceLoad(final String division)
     {
+        // The below technique is tighter coupling with VistALink than I would like, but
+        // I couldn't find a better way. - David Tombs, 31-Aug-2015
         try
         {
-            final String station = getStationFromDivision(division);
+            final String station = STATION_RULES.getPrimaryStationLookupString(division);
             final String configuredJndiName =
                     ConfigurationReader.getJndiNameForStationNumber(station);
             LOGGER.trace(
@@ -90,8 +90,8 @@ public class VistaLinkUtil
             /*
              * This isn't pretty: VistALink relies on the connectors being eagerly-loaded
              * like WebLogic does, but it isn't standard across application servers. The
-             * VistALink code contains the below hack to force initialization but for some
-             * reason only enables it on Websphere.
+             * below hack supports other application servers (e.g., GlassFish and probably
+             * Websphere).
              */
             tryForceLoad(division);
 

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkAuthenticatorTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkAuthenticatorTest.java
@@ -22,14 +22,14 @@ public class VistaLinkAuthenticatorTest
     public final void setUp() throws Exception
     {
         // VistaLinkProcedureCaller needs this.
-        VistaLinkProcedureCallerTest.setupJndiForVistaLink();
+        VistaLinkUtilTest.setupJndiForVistaLink();
     }
     
     @Test
     public final void testAuthenticateViaAccessVerify() throws Exception
     {
         final VistaLinkAuthenticator authenticator = new VistaLinkAuthenticator(
-                VistaLinkProcedureCallerTest.SUPPORTED_DIVISON);
+                VistaLinkUtilTest.SUPPORTED_DIVISON);
         
         final VistaPerson actualVistaPerson = authenticator.authenticateViaAccessVerify(
                 MockVistaLinkConnection.RADIOLOGIST_ACCESS_CODE,
@@ -48,7 +48,7 @@ public class VistaLinkAuthenticatorTest
     public final void testAuthenticateViaAccessVerifyInvalid() throws Exception
     {
         final VistaLinkAuthenticator authenticator = new VistaLinkAuthenticator(
-                VistaLinkProcedureCallerTest.SUPPORTED_DIVISON);
+                VistaLinkUtilTest.SUPPORTED_DIVISON);
         
         authenticator.authenticateViaAccessVerify("bob", "robert", "192.168.1.4");
     }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCallerTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkProcedureCallerTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.naming.NamingException;
-import javax.resource.ResourceException;
 import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.LoginException;
 
@@ -14,45 +12,19 @@ import gov.va.med.srcalc.domain.VistaLabs;
 import gov.va.med.srcalc.vista.RemoteProcedure;
 import gov.va.med.srcalc.vista.vistalink.VistaLinkProcedureCaller;
 import gov.va.med.vistalink.adapter.cci.VistaLinkDuzConnectionSpec;
-import gov.va.med.vistalink.institution.InstitutionMapping;
-import gov.va.med.vistalink.institution.InstitutionMappingBadStationNumberException;
-import gov.va.med.vistalink.institution.InstitutionMappingFactory;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
 
 /**
  * Tests the {@link VistaLinkProcedureCaller} class.
  */
 public class VistaLinkProcedureCallerTest
 {
-    /**
-     * The division which {@link #setupJndiForVistaLink()} populates.
-     */
-    static final String SUPPORTED_DIVISON = "500";
-    
-    private final static String VLCF_JNDI_NAME = "java:comp/env/vlj/Asrc500";
-    
-    /**
-     * Populate JNDI with a {@link MockVistaLinkConnectionFactory} and configures
-     * VistALink accordingly.
-     */
-    static void setupJndiForVistaLink()
-            throws NamingException, ResourceException, InstitutionMappingBadStationNumberException
-    {
-        SimpleNamingContextBuilder builder =
-                SimpleNamingContextBuilder.emptyActivatedContextBuilder();
-        builder.bind(VLCF_JNDI_NAME, new MockVistaLinkConnectionFactory());
-        // Simulate VistALink self-configuration.
-        InstitutionMapping mapping = InstitutionMappingFactory.getInstitutionMapping();
-        mapping.loadMappingsForJndiName(VLCF_JNDI_NAME, new String[] {"500"}, 100);
-    }
-
     @Before
     public void setUp() throws Exception
     {
-        setupJndiForVistaLink();
+        VistaLinkUtilTest.setupJndiForVistaLink();
     }
     
     /**
@@ -63,7 +35,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoUserRpc() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         
         final List<String> results = caller.doRpc(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ, RemoteProcedure.GET_USER_INFO);
@@ -75,7 +47,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoPatientRpc() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         final List<String> results = caller.doRpc(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ,
                 RemoteProcedure.GET_PATIENT,
@@ -89,7 +61,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoSaveProgressNoteCall() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         final String result = caller.doSaveProgressNoteCall(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ,
                 "fakeEncryptedSig",
@@ -103,7 +75,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoSaveRiskCalculationCall() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         final String result = caller.doSaveRiskCalculationCall(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ,
                 MockVistaLinkConnection.PATIENT_DFN,
@@ -118,7 +90,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoRetrieveLabsCallSgot() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         final String result = caller.doRetrieveLabsCall(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ,
                 MockVistaLinkConnection.PATIENT_DFN,
@@ -131,7 +103,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDoRetrieveLabsCallAlbumin() throws Exception
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         final String result = caller.doRetrieveLabsCall(
                 MockVistaLinkConnection.RADIOLOGIST_DUZ,
                 MockVistaLinkConnection.PATIENT_DFN,
@@ -158,10 +130,10 @@ public class VistaLinkProcedureCallerTest
     public final void testUnknownDuzConnectionSpec() throws LoginException
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         
         final VistaLinkDuzConnectionSpec cs = new VistaLinkDuzConnectionSpec(
-                SUPPORTED_DIVISON, "11111");
+                VistaLinkUtilTest.SUPPORTED_DIVISON, "11111");
         caller.doRpc(cs, RemoteProcedure.GET_USER_INFO);
     }
     
@@ -173,7 +145,7 @@ public class VistaLinkProcedureCallerTest
     public final void testUnknownDuz() throws LoginException
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         caller.doRpc("12222", RemoteProcedure.GET_USER_PERSON_CLASSES);
     }
     
@@ -181,7 +153,7 @@ public class VistaLinkProcedureCallerTest
     public final void testDisabledDuz() throws LoginException
     {
         final VistaLinkProcedureCaller caller =
-                new VistaLinkProcedureCaller(SUPPORTED_DIVISON);
+                new VistaLinkProcedureCaller(VistaLinkUtilTest.SUPPORTED_DIVISON);
         
         caller.doRpc(MockVistaLinkConnection.DISABLED_DUZ, RemoteProcedure.GET_USER_INFO);
     }

--- a/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtilTest.java
+++ b/srcalc/src/test/java/gov/va/med/srcalc/vista/vistalink/VistaLinkUtilTest.java
@@ -1,0 +1,61 @@
+package gov.va.med.srcalc.vista.vistalink;
+
+import static org.junit.Assert.*;
+import gov.va.med.vistalink.institution.InstitutionMapping;
+import gov.va.med.vistalink.institution.InstitutionMappingBadStationNumberException;
+import gov.va.med.vistalink.institution.InstitutionMappingFactory;
+
+import javax.naming.NamingException;
+import javax.resource.ResourceException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+
+/**
+ * Unit tests for {@link VistaLinkUtil}. Using BDD-style tests.
+ */
+public class VistaLinkUtilTest
+{
+    /**
+     * The division which {@link setupJndiForVistaLink} populates.
+     */
+    static final String SUPPORTED_DIVISON = "500";
+
+    private final static String VLCF_JNDI_NAME = "java:comp/env/vlj/Asrc500";
+
+    /**
+     * Populate JNDI with a {@link MockVistaLinkConnectionFactory} and configures
+     * VistALink accordingly.
+     */
+    static void setupJndiForVistaLink()
+            throws NamingException, ResourceException, InstitutionMappingBadStationNumberException
+    {
+        SimpleNamingContextBuilder builder =
+                SimpleNamingContextBuilder.emptyActivatedContextBuilder();
+        builder.bind(VLCF_JNDI_NAME, new MockVistaLinkConnectionFactory());
+        // Simulate VistALink self-configuration.
+        final InstitutionMapping mapping =
+                InstitutionMappingFactory.getInstitutionMapping();
+        mapping.loadMappingsForJndiName(
+                VLCF_JNDI_NAME, new String[] {SUPPORTED_DIVISON}, 100);
+    }
+    
+    @Before
+    public void setUp() throws Exception
+    {
+        setupJndiForVistaLink();
+    }
+
+    @Test
+    public final void shouldReturnFalseForUnknownDivision()
+    {
+        assertEquals(false, VistaLinkUtil.isDivisionKnown("222"));
+    }
+    
+    @Test
+    public final void shouldReturnTrueForKnownDivision()
+    {
+        assertEquals(true, VistaLinkUtil.isDivisionKnown(SUPPORTED_DIVISON));
+    }
+}

--- a/vljRar/src/META-INF/ra.xml
+++ b/vljRar/src/META-INF/ra.xml
@@ -24,7 +24,10 @@
 		    connectorJndiName property. It overrides this one! -->
 		    <config-property-name>connectorJndiName</config-property-name>
 		    <config-property-type>java.lang.String</config-property-type>
-		    <config-property-value>vljPlaceholder</config-property-value>
+		    <!-- Note: not specifying the placeholder connectorJndiName
+		    value. This deviates from the VistALink-supplied ra.xml but
+		    avoids an Exception upon startup in GlassFish and should still
+		    work in all containers. -->
 		</config-property>
 		<connectionfactory-interface>javax.resource.cci.ConnectionFactory</connectionfactory-interface>
 		<connectionfactory-impl-class>gov.va.med.vistalink.adapter.cci.VistaLinkConnectionFactory</connectionfactory-impl-class>


### PR DESCRIPTION
Implement a hack to force initialization of the division -> JNDI name mapping.